### PR TITLE
Improvements to about_generators.py

### DIFF
--- a/python 2/koans/about_generators.py
+++ b/python 2/koans/about_generators.py
@@ -104,7 +104,15 @@ class AboutGenerators(Koan):
         next(generator)
 
         self.assertEqual(__, generator.send(1 + 2))
-                
+
+    def test_before_sending_a_value_to_a_generator_next_must_be_called(self):
+        generator = self.generator_with_coroutine()
+
+        try:
+            generator.send(1+2)
+        except TypeError as ex:
+            self.assertMatch(__, ex[0])
+
     # ------------------------------------------------------------------
     
     def yield_tester(self):

--- a/python 3/koans/about_generators.py
+++ b/python 3/koans/about_generators.py
@@ -107,6 +107,14 @@ class AboutGenerators(Koan):
         next(generator)
 
         self.assertEqual(__, generator.send(1 + 2))
+
+    def test_before_sending_a_value_to_a_generator_next_must_be_called(self):
+        generator = self.generator_with_coroutine()
+
+        try:
+            generator.send(1+2)
+        except TypeError as ex:
+            self.assertMatch(__, ex[0])
                 
     # ------------------------------------------------------------------
     


### PR DESCRIPTION
I've made a few improvements to the AboutGenerators koan:
- Added a "THINK ABOUT IT" comment regarding why the first call to a generator must be a next(), and not sending a non-None argument.
- Added a test to demonstrate the above behaviour.
- Added a test demonstrating that send(None) is equivalent to next()
- Fixed the two small issues in the git bug tracker: "sum_it not interesting" and "cube_me squares".

If there are any improvements you'd like to see to any of the above commits, let me know.
