### PR TITLE
Changing tuple tests to be a little more contemplative

### DIFF
--- a/python 2/koans/about_tuples.py
+++ b/python 2/koans/about_tuples.py
@@ -37,10 +37,12 @@ class AboutTuples(Koan):
         
         self.assertEqual(__, count_of_three)
 
-    def test_tuples_of_one_are_peculiar(self):
-        self.assertEqual(__, (1))
-        self.assertEqual(__, ("Hello comma!", ))
-        self.assertEqual(__, (1,))
+    def test_tuples_of_one_look_peculiar(self):
+        self.assertEqual(__, (1).__class__.__name__)
+        self.assertEqual(__, (1,).__class__.__name__)
+        self.assertEqual(__, ("Hello comma!", ).__class__.__name__)
+        
+    def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))
 
     def test_creating_empty_tuples(self):

--- a/python 3/koans/about_tuples.py
+++ b/python 3/koans/about_tuples.py
@@ -35,10 +35,12 @@ class AboutTuples(Koan):
         
         self.assertEqual(__, count_of_three)
 
-    def test_tuples_of_one_are_peculiar(self):
-        self.assertEqual(__, (1))
-        self.assertEqual(__, ("Hello comma!", ))
-        self.assertEqual(__, (1,))
+    def test_tuples_of_one_look_peculiar(self):
+        self.assertEqual(__, (1).__class__.__name__)
+        self.assertEqual(__, (1,).__class__.__name__)
+        self.assertEqual(__, ("Hello comma!", ).__class__.__name__)
+        
+    def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))
 
     def test_creating_empty_tuples(self):


### PR DESCRIPTION
The tests list:
self.assertEqual(__, (1))

Could be answered as self.assertEqual(1, (1)), which shows understanding that one item in parens isn't a tuple. But it could also be answered as self.assertEqual((1), (1)), which shows understanding of copy/paste. Changing these to use class name instead.
