### PR TITLE
Demonstrate empty dictionary literals

### DIFF
--- a/python 2/koans/about_dictionaries.py
+++ b/python 2/koans/about_dictionaries.py
@@ -16,6 +16,8 @@ class AboutDictionaries(Koan):
         self.assertEqual(__, len(empty_dict))
         
     def test_dictionary_literals(self):
+        empty_dict = {}
+        self.assertEqual(dict, type(empty_dict))
         babel_fish = {'one': "uno", 'two': "dos"}
         self.assertEqual(__, len(babel_fish))
         

--- a/python 3/koans/about_dictionaries.py
+++ b/python 3/koans/about_dictionaries.py
@@ -15,6 +15,8 @@ class AboutDictionaries(Koan):
         self.assertEqual(__, len(empty_dict))
         
     def test_dictionary_literals(self):
+        empty_dict = {}
+        self.assertEqual(dict, type(empty_dict))
         babel_fish = { 'one': "uno", 'two': "dos" }
         self.assertEqual(__, len(babel_fish))
         


### PR DESCRIPTION
Small suggestion, but I thought it might be somewhat useful for someone learning Python.

The first test creates an empty dictionary with dict() and tests its length. It might be nice to mimic that in the following test on dict literals; show how the same thing works with the other syntax before putting stuff in one and testing that length.
