### PR TITLE
enclose string literals of dictionary values with single quotes

### DIFF
--- a/python2/koans/about_dictionaries.py
+++ b/python2/koans/about_dictionaries.py
@@ -18,36 +18,36 @@ class AboutDictionaries(Koan):
     def test_dictionary_literals(self):
         empty_dict = {}
         self.assertEqual(dict, type(empty_dict))
-        babel_fish = {'one': "uno", 'two': "dos"}
+        babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish))
         
     def test_accessing_dictionaries(self):
-        babel_fish = {'one': "uno", 'two': "dos"}
+        babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, babel_fish['one'])
         self.assertEqual(__, babel_fish['two'])
         
     def test_changing_dictionaries(self):
-        babel_fish = {'one': "uno", 'two': "dos"}
-        babel_fish['one'] = "eins"
+        babel_fish = {'one': 'uno', 'two': 'dos'}
+        babel_fish['one'] = 'eins'
         
-        expected = {'two': "dos", 'one': __}
+        expected = {'two': 'dos', 'one': __}
         self.assertEqual(expected, babel_fish)
         
     def test_dictionary_is_unordered(self):
-        dict1 = {'one': "uno", 'two': "dos"}
-        dict2 = {'two': "dos", 'one': "uno"}
+        dict1 = {'one': 'uno', 'two': 'dos'}
+        dict2 = {'two': 'dos', 'one': 'uno'}
         
         self.assertEqual(____, dict1 == dict2)
         
     def test_dictionary_keys(self):
-        babel_fish = {'one': "uno", 'two': "dos"}
+        babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish.keys()))
         self.assertEqual(__, 'one' in babel_fish)
         self.assertEqual(__, 'two' in babel_fish)
         self.assertEqual(list, babel_fish.keys().__class__)
         
     def test_dictionary_values(self):
-        babel_fish = {'one': "uno", 'two': "dos"}
+        babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish.values()))
         self.assertEqual(__, 'uno' in babel_fish.values())
         self.assertEqual(__, 'dos' in babel_fish.values())
@@ -55,10 +55,10 @@ class AboutDictionaries(Koan):
         
     def test_making_a_dictionary_from_a_sequence_of_keys(self):
         cards = {}.fromkeys(
-            ("red warrior", "green elf", "blue valkyrie", "yellow dwarf",
-             "confused looking zebra"),
+            ('red warrior', 'green elf', 'blue valkyrie', 'yellow dwarf',
+             'confused looking zebra'),
             42)
         
         self.assertEqual(__, len(cards))
-        self.assertEqual(__, cards["green elf"])
-        self.assertEqual(__, cards["yellow dwarf"])
+        self.assertEqual(__, cards['green elf'])
+        self.assertEqual(__, cards['yellow dwarf'])

--- a/python3/koans/about_dictionaries.py
+++ b/python3/koans/about_dictionaries.py
@@ -17,45 +17,45 @@ class AboutDictionaries(Koan):
     def test_dictionary_literals(self):
         empty_dict = {}
         self.assertEqual(dict, type(empty_dict))
-        babel_fish = { 'one': "uno", 'two': "dos" }
+        babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, len(babel_fish))
         
     def test_accessing_dictionaries(self):
-        babel_fish = { 'one': "uno", 'two': "dos" }
+        babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, babel_fish['one'])
         self.assertEqual(__, babel_fish['two'])
         
     def test_changing_dictionaries(self):
-        babel_fish = { 'one': "uno", 'two': "dos" }
-        babel_fish['one'] = "eins"
+        babel_fish = { 'one': 'uno', 'two': 'dos' }
+        babel_fish['one'] = 'eins'
         
-        expected = { 'two': "dos", 'one': __ }
+        expected = { 'two': 'dos', 'one': __ }
         self.assertDictEqual(expected, babel_fish)
         
     def test_dictionary_is_unordered(self):
-        dict1 = { 'one': "uno", 'two': "dos" }
-        dict2 = { 'two': "dos", 'one': "uno" }
+        dict1 = { 'one': 'uno', 'two': 'dos' }
+        dict2 = { 'two': 'dos', 'one': 'uno' }
         
         self.assertEqual(__, dict1 == dict2)
         
     def test_dictionary_keys(self):
-        babel_fish = { 'one': "uno", 'two': "dos" }
+        babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, len(babel_fish.keys()))
         self.assertEqual(__, 'one' in babel_fish) 
         self.assertEqual(__, 'two' in babel_fish) 
         self.assertEqual('dict_keys', babel_fish.keys().__class__.__name__)
         
     def test_dictionary_values(self):
-        babel_fish = { 'one': "uno", 'two': "dos" }
+        babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, len(babel_fish.values()))
         self.assertEqual(__, 'uno' in babel_fish.values())
         self.assertEqual(__, 'dos' in babel_fish.values())
         self.assertEqual('dict_values', babel_fish.values().__class__.__name__)
         
     def test_making_a_dictionary_from_a_sequence_of_keys(self):
-        cards = {}.fromkeys(("red warrior", "green elf", "blue valkyrie", "yellow dwarf", "confused looking zebra"), 42)
+        cards = {}.fromkeys(('red warrior', 'green elf', 'blue valkyrie', 'yellow dwarf', 'confused looking zebra'), 42)
         
         self.assertEqual(__, len(cards))
-        self.assertEqual(__, cards["green elf"])
-        self.assertEqual(__, cards["yellow dwarf"])
+        self.assertEqual(__, cards['green elf'])
+        self.assertEqual(__, cards['yellow dwarf'])
 


### PR DESCRIPTION
for consistency
