### PR TITLE
Fix punctuation error in comment

### DIFF
--- a/python2/koans/about_proxy_object_project.py
+++ b/python2/koans/about_proxy_object_project.py
@@ -13,7 +13,7 @@
 # missing handler and any other supporting methods.  The specification
 # of the Proxy class is given in the AboutProxyObjectProject koan.
 
-# Note: This is a bit trickier that it's Ruby Koans counterpart, but you
+# Note: This is a bit trickier that its Ruby Koans counterpart, but you
 # can do it!
 
 from runner.koan import *


### PR DESCRIPTION
`it's` -> `its`

This has been bothering me.
