### PR TITLE
There is a minor error in the python 'about proxy object project' test code that needs correction as listed below.

### DIFF
--- a/python3/koans/about_proxy_object_project.py
+++ b/python3/koans/about_proxy_object_project.py
@@ -51,7 +51,7 @@ class AboutProxyObjectProject(Koan):
         tv.power()
         tv.channel = 10
         
-        self.assertEqual(['power', 'channel='], tv.messages())
+        self.assertEqual(['power', 'channel'], tv.messages())
     
     def test_proxy_handles_invalid_messages(self):
         tv = Proxy(Television())
@@ -78,7 +78,7 @@ class AboutProxyObjectProject(Koan):
         tv.power()
       
         self.assertEqual(2, tv.number_of_times_called('power'))
-        self.assertEqual(1, tv.number_of_times_called('channel='))
+        self.assertEqual(1, tv.number_of_times_called('channel'))
         self.assertEqual(0, tv.number_of_times_called('is_on'))
     
     def test_proxy_can_record_more_than_just_tv_objects(self):


### PR DESCRIPTION
The proxy object project koan checks for 'channel=' in its tests to check the Television object properties. The tests need a change so that they check for the 'channel' string instead of the 'channel=' string. This is more consistent with Python functionality and the '=' sign is unnecessary in the test unlike in the ruby koans.

This commit fixes the issue in the python3 version of the koan.
