### PR TITLE
Change sets for set operators to be more intuitive

### DIFF
--- a/python2/koans/about_sets.py
+++ b/python2/koans/about_sets.py
@@ -21,17 +21,14 @@ class AboutSets(Koan):
         
     # ------------------------------------------------------------------
 
-    def chars_in(self, a_set):
-        return ''.join(sorted(a_set))
-
     def test_set_have_arithmetic_operators(self):
-        good_guy = set('macleod')
-        bad_guy = set('mutunas')
-        
-        self.assertEqual(__, self.chars_in(good_guy - bad_guy))
-        self.assertEqual(__, self.chars_in(good_guy | bad_guy))
-        self.assertEqual(__, self.chars_in(good_guy & bad_guy))
-        self.assertEqual(__, self.chars_in(good_guy ^ bad_guy))
+        scotsmen = set(["MacLeod","Wallace","Willie"])
+        warriors = set(["MacLeod", "Wallace", "Leonidas"])
+
+        self.assertEqual(__, scotsmen - warriors)
+        self.assertEqual(__, scotsmen | warriors)
+        self.assertEqual(__, scotsmen & warriors)
+        self.assertEqual(__, scotsmen ^ warriors)
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
Using actual people for these sets makes it much clearer what the
-, |, & and ^ symbols actually mean.
