### PR TITLE
Update python2/koans/about_tuples.py

### DIFF
--- a/python2/koans/about_tuples.py
+++ b/python2/koans/about_tuples.py
@@ -41,7 +41,7 @@ class AboutTuples(Koan):
     def test_tuples_of_one_look_peculiar(self):
         self.assertEqual(__, (1).__class__.__name__)
         self.assertEqual(__, (1,).__class__.__name__)
-        self.assertEqual(__, ("Hello comma!", ))
+        self.assertEqual(__, ("Hello comma!", ).__class__.__name__)
         
     def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))


### PR DESCRIPTION
The intent seems to be to test the knowledge of the class name of the tuple, and hence this recommended fix.
