### PR TITLE
Importing a subfolder without the __init__ method

### DIFF
--- a/python3/koans/about_packages.py
+++ b/python3/koans/about_packages.py
@@ -39,7 +39,7 @@ class AboutPackages(Koan):
         
     def test_subfolders_without_an_init_module_are_not_part_of_the_package(self):
         # Import ./a_normal_folder/
-        with self.assertRaises(___): from . import a_normal_folder
+        with self.assertRaises(___): from a_normal_folder import Duck
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
As of Python 3.3, importing a subfolder without the **init** method does not raise any exception in test_subfolders_without_an_init_module_are_not_part_of_the_package. Trying to import something from it does the trick. This should fix issue #35 

Signed-off-by: DeK nofatclips@gmail.com
