### PR TITLE
Respect exit codes when there are koans failing

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -3,6 +3,7 @@
 
 import unittest
 import re
+import sys
 import glob
 
 import helper
@@ -88,7 +89,7 @@ class Sensei(MockableTestResult):
         self.stream.writeln("")
         self.stream.writeln(self.say_something_zenlike())
         
-        if self.failures: return
+        if self.failures: sys.exit(-1)
         self.stream.writeln(
             "\n{0}**************************************************" \
             .format(Fore.RESET))


### PR DESCRIPTION
This should help continuous integration systems like Travis-CI or Jenkins to determine whether the student has reached Zen illumination, automatically ;)

We are giving a python course at our organization:

https://github.com/pythonkurs

This pull request will help us monitor whether the students pass or fail the assignment (your koans).

@guillermo-carrasco, @vals, @OxanaSachenkova and @hugerth are senseis in this course.
