### PR TITLE
Modified: python*/runner/sensei.py to fix progress message.

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -157,11 +157,16 @@ class Sensei(MockableTestResult):
         return scrape.replace(sep, '\n').strip('\n')
 
     def report_progress(self):
-        return ("You are now {0}/{1} koans and {2}/{3} lessons away from " \
-                "reaching enlightenment".format(self.pass_count,
-                                                self.total_koans(),
-                                                self.lesson_pass_count,
-                                                self.total_lessons()))
+        koans_complete = self.pass_count
+        lessons_complete = self.lesson_pass_count
+        koans_remaining = self.total_koans() - koans_complete
+        lessons_remaining = self.total_lessons() - lessons_complete
+
+        sent1 = "You have completed {0} koans and " \
+                "{1} lessons.\n".format(koans_complete, lessons_complete)
+        sent2 = "You are now {0} koans and {1} lessons away from " \
+                "reaching enlightenment.".format(koans_remaining, lessons_remaining)
+        return sent1+sent2
 
     # Hat's tip to Tim Peters for the zen statements from The Zen
     # of Python (http://www.python.org/dev/peps/pep-0020/)

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -156,11 +156,16 @@ class Sensei(MockableTestResult):
         return scrape.replace(sep, '\n').strip('\n')
 
     def report_progress(self):
-        return ("You are now {0}/{1} koans and {2}/{3} lessons away from " \
-                "reaching enlightenment".format(self.pass_count,
-                                                self.total_koans(),
-                                                self.lesson_pass_count,
-                                                self.total_lessons()))   
+        koans_complete = self.pass_count
+        lessons_complete = self.lesson_pass_count
+        koans_remaining = self.total_koans() - koans_complete
+        lessons_remaining = self.total_lessons() - lessons_complete
+
+        sent1 = "You have completed {0} koans and " \
+                "{1} lessons.\n".format(koans_complete, lessons_complete)
+        sent2 = "You are now {0} koans and {1} lessons away from " \
+                "reaching enlightenment.".format(koans_remaining, lessons_remaining)
+        return sent1+sent2  
 
     # Hat's tip to Tim Peters for the zen statements from The Zen
     # of Python (http://www.python.org/dev/peps/pep-0020/)


### PR DESCRIPTION
The previous sensei message tells the user they are "{completed}/
{total} lessons away from enlightenment."  This is not a true
statement since your fractional progress is not equal to your
distance from enlightenment.  I have modified the report_progress
function to return a two line string.  The first line reports the
total progress and the second line tells them they are {total-
completed} koans away from enlightenment.

I modified report_progress() in both python2/runner/sensei.py
and python3/runner/sensei.py
![Screen Shot 2013-02-15 at 10 31 09 PM](https://f.cloud.github.com/assets/1326365/163152/7a94ba0a-7802-11e2-96ec-c3ea3574ffef.png)
