### PR TITLE
Fixes trailing white space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ notifications:
 
 # Some other koans (see runner/sensei.py or "ls koans" to see the light):
 #
-# about_none about_lists about_list_assignments about_dictionaries 
-# about_strings about_tuples about_methods about_control_statements 
+# about_none about_lists about_list_assignments about_dictionaries
+# about_strings about_tuples about_methods about_control_statements
 # about_true_and_false about_sets ...

--- a/Contributor Notes.txt
+++ b/Contributor Notes.txt
@@ -9,7 +9,7 @@ Running a whole test case:
   $ python contemplate_koans.py about_strings
   or
   $ python3 contemplate_koans.py about_strings
-  
+
   Running a single test:
 
   $ python contemplate_koans.py about_strings.AboutStrings.test_triple_quoted_strings_need_less_escaping

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Python Koans is a port of Edgecase's "Ruby Koans".
 
 .. image:: http://i442.photobucket.com/albums/qq150/gregmalcolm/PythonKoansScreenshot.png
 
-Python Koans is an interactive tutorial for learning Python by making tests pass. 
+Python Koans is an interactive tutorial for learning Python by making tests pass.
 
 Most tests are 'fixed' by filling the missing parts of assert functions. Eg:
 
@@ -40,7 +40,7 @@ Installing Python Koans
 
 Aside from downloading or checking out the latest version of Python Koans, all you need to install is Python.
 
-At this time of writing there are two versions of the koans, one for use with Python 2.6 and one for Python 3.1. You should be able to work with newer Python versions, but older ones will likely give you problems. 
+At this time of writing there are two versions of the koans, one for use with Python 2.6 and one for Python 3.1. You should be able to work with newer Python versions, but older ones will likely give you problems.
 
 You can download Python from here:
 
@@ -99,11 +99,11 @@ Getting the Most From the Koans
 
 Quoting the Ruby Koans instructions::
 
-	"In test-driven development the mantra has always been, red, green, 
+	"In test-driven development the mantra has always been, red, green,
 	refactor. Write a failing test and run it (red), make the test pass
 	(green), then refactor it (that is look at the code and see if you
 	can make it any better. In this case you will need to run the koan
-	and see it fail (red), make the test pass (green), then take a 
+	and see it fail (red), make the test pass (green), then take a
 	moment and reflect upon the test to see what it is teaching you
 	and improve the code to better communicate its intent (refactor)."
 

--- a/python2/_runner_tests.py
+++ b/python2/_runner_tests.py
@@ -17,4 +17,3 @@ def suite():
 
 if __name__ == '__main__':
     unittest.TextTestRunner(verbosity=2).run(suite())
-    

--- a/python2/contemplate_koans.py
+++ b/python2/contemplate_koans.py
@@ -14,7 +14,7 @@ import unittest
 import sys
 
 
-if __name__ == '__main__':        
+if __name__ == '__main__':
     if sys.version_info >= (3, 0):
         print("\nThis is the Python 2 version of Python Koans, but you are " +
             "running it with Python 3 or newer!\n\n"
@@ -31,7 +31,7 @@ if __name__ == '__main__':
                 "to work!\n\n" +
                 "But lets see how far we get...\n" +
                 "********************************************************\n")
-        
+
         from runner.mountain import Mountain
 
         Mountain().walk_the_path(sys.argv)

--- a/python2/koans/about_decorating_with_classes.py
+++ b/python2/koans/about_decorating_with_classes.py
@@ -19,10 +19,10 @@ class AboutDecoratingWithClasses(Koan):
         the partial.
         """
         max = functools.partial(self.maximum)
-        
+
         self.assertEqual(__, max(7, 23))
         self.assertEqual(__, max(10, -10))
-        
+
     def test_partial_that_wrappers_first_arg(self):
         max0 = functools.partial(self.maximum, 0)
 
@@ -41,10 +41,10 @@ class AboutDecoratingWithClasses(Koan):
     class doubleit(object):
         def __init__(self, fn):
             self.fn = fn
-    
+
         def __call__(self, *args):
             return self.fn(*args) + ', ' + self.fn(*args)
-    
+
         def __get__(self, obj, cls=None):
             if not obj:
                 # Decorating an unbound function
@@ -56,15 +56,15 @@ class AboutDecoratingWithClasses(Koan):
     @doubleit
     def foo(self):
         return "foo"
-    
+
     @doubleit
     def parrot(self, text):
         return text.upper()
-                
+
     def test_decorator_with_no_arguments(self):
         # To clarify: the decorator above the function has no arguments, even
         # if the decorated function does
-                
+
         self.assertEqual(__, self.foo())
         self.assertEqual(__, self.parrot('pieces of eight'))
 
@@ -77,7 +77,7 @@ class AboutDecoratingWithClasses(Koan):
     def test_what_a_decorator_is_doing_to_a_function(self):
         #wrap the function with the decorator
         self.sound_check = self.doubleit(self.sound_check)
-        
+
         self.assertEqual(__, self.sound_check())
 
     # ------------------------------------------------------------------
@@ -85,17 +85,17 @@ class AboutDecoratingWithClasses(Koan):
     class documenter(object):
         def __init__(self, *args):
             self.fn_doc = args[0]
-    
+
         def __call__(self, fn):
             def decorated_function(*args):
                 return fn(*args)
-                
+
             if fn.__doc__:
                 decorated_function.__doc__ = fn.__doc__ + ": " + self.fn_doc
             else:
                 decorated_function.__doc__ = self.fn_doc
             return decorated_function
-        
+
     @documenter("Increments a value by one. Kind of.")
     def count_badly(self, num):
         num += 1
@@ -117,7 +117,7 @@ class AboutDecoratingWithClasses(Koan):
         self.assertEqual(__, self.idler.__doc__)
 
     # ------------------------------------------------------------------
-        
+
     @documenter("DOH!")
     @doubleit
     @doubleit

--- a/python2/koans/about_decorating_with_functions.py
+++ b/python2/koans/about_decorating_with_functions.py
@@ -3,30 +3,30 @@
 
 from runner.koan import *
 
-            
+
 class AboutDecoratingWithFunctions(Koan):
     def addcowbell(fn):
         fn.wow_factor = 'COWBELL BABY!'
         return fn
-            
+
     @addcowbell
     def mediocre_song(self):
         return "o/~ We all live in a broken submarine o/~"
-                
+
     def test_decorators_can_modify_a_function(self):
         self.assertMatch(__, self.mediocre_song())
         self.assertEqual(__, self.mediocre_song.wow_factor)
-    
+
     # ------------------------------------------------------------------
 
     def xmltag(fn):
         def func(*args):
             return '<' + fn(*args) + '/>'
         return func
-            
+
     @xmltag
     def render_tag(self, name):
         return name
-    
+
     def test_decorators_can_change_a_function_output(self):
         self.assertEqual(__, self.render_tag('llama'))

--- a/python2/koans/about_deleting_objects.py
+++ b/python2/koans/about_deleting_objects.py
@@ -9,9 +9,9 @@ class AboutDeletingObjects(Koan):
         lottery_nums = [4, 8, 15, 16, 23, 42]
         del lottery_nums[1]
         del lottery_nums[2:4]
-        
+
         self.assertEqual(__, lottery_nums)
-        
+
     def test_del_can_remove_entire_lists(self):
         lottery_nums = [4, 8, 15, 16, 23, 42]
         del lottery_nums
@@ -20,28 +20,28 @@ class AboutDeletingObjects(Koan):
         except Exception as e:
             pass
         self.assertMatch(__, e[0])
-        
+
     # --------------------------------------------------------------------
-        
+
     class ClosingSale(object):
         def __init__(self):
             self.hamsters = 7
             self.zebras = 84
-            
+
         def cameras(self):
             return 34
-        
+
         def toilet_brushes(self):
             return 48
-        
+
         def jellies(self):
             return 5
-        
+
     def test_del_can_remove_attributes(self):
         crazy_discounts = self.ClosingSale()
         del self.ClosingSale.toilet_brushes
         del crazy_discounts.hamsters
-        
+
         try:
             still_available = crazy_discounts.toilet_brushes()
         except AttributeError as e:
@@ -51,7 +51,7 @@ class AboutDeletingObjects(Koan):
             still_available = crazy_discounts.hamsters
         except AttributeError as e:
             err_msg2 = e.args[0]
-        
+
         self.assertMatch(__, err_msg1)
         self.assertMatch(__, err_msg2)
 
@@ -60,7 +60,7 @@ class AboutDeletingObjects(Koan):
     class ClintEastwood(object):
         def __init__(self):
             self._name = None
-            
+
         def get_name(self):
             try:
                 return self._name
@@ -69,13 +69,13 @@ class AboutDeletingObjects(Koan):
 
         def set_name(self, name):
             self._name = name
-            
+
         def del_name(self):
             del self._name
-            
+
         name = property(get_name, set_name, del_name, \
             "Mr Eastwood's current alias")
-            
+
     def test_del_works_with_properties(self):
         cowboy = self.ClintEastwood()
         cowboy.name = 'Senor Ninguno'
@@ -83,13 +83,13 @@ class AboutDeletingObjects(Koan):
 
         del cowboy.name
         self.assertEqual(__, cowboy.name)
-        
+
     # --------------------------------------------------------------------
 
     class Prisoner(object):
         def __init__(self):
             self._name = None
-        
+
         @property
         def name(self):
             return self._name
@@ -97,11 +97,11 @@ class AboutDeletingObjects(Koan):
         @name.setter
         def name(self, name):
             self._name = name
-            
+
         @name.deleter
         def name(self):
             self._name = 'Number Six'
-                        
+
     def test_another_way_to_make_a_deletable_property(self):
         citizen = self.Prisoner()
         citizen.name = "Patrick"
@@ -111,12 +111,12 @@ class AboutDeletingObjects(Koan):
         self.assertEqual(__, citizen.name)
 
     # --------------------------------------------------------------------
-        
+
     class MoreOrganisedClosingSale(ClosingSale):
         def __init__(self):
             self.last_deletion = None
             super(AboutDeletingObjects.ClosingSale, self).__init__()
-        
+
         def __delattr__(self, attr_name):
             self.last_deletion = attr_name
 

--- a/python2/koans/about_dice_project.py
+++ b/python2/koans/about_dice_project.py
@@ -9,11 +9,11 @@ import random
 class DiceSet(object):
     def __init__(self):
         self._values = None
-    
+
     @property
     def values(self):
         return self._values
-              
+
     def roll(self, n):
         # Needs implementing!
         # Tip: random.randint(min, max) can be used to generate random numbers
@@ -27,7 +27,7 @@ class AboutDiceProject(Koan):
 
     def test_rolling_the_dice_returns_a_set_of_integers_between_1_and_6(self):
         dice = DiceSet()
-        
+
         dice.roll(5)
         self.assertTrue(isinstance(dice.values, list), "should be a list")
         self.assertEqual(5, len(dice.values))
@@ -35,37 +35,37 @@ class AboutDiceProject(Koan):
             self.assertTrue(
                 value >= 1 and value <= 6,
                 "value " + str(value) + " must be between 1 and 6")
-        
+
     def test_dice_values_do_not_change_unless_explicitly_rolled(self):
         dice = DiceSet()
         dice.roll(5)
         first_time = dice.values
         second_time = dice.values
         self.assertEqual(first_time, second_time)
-        
+
     def test_dice_values_should_change_between_rolls(self):
         dice = DiceSet()
-        
+
         dice.roll(5)
         first_time = dice.values
-        
+
         dice.roll(5)
         second_time = dice.values
-        
+
         self.assertNotEqual(first_time, second_time, \
             "Two rolls should not be equal")
-        
+
         # THINK ABOUT IT:
         #
         # If the rolls are random, then it is possible (although not
         # likely) that two consecutive rolls are equal.  What would be a
         # better way to test this?
-        
+
     def test_you_can_roll_different_numbers_of_dice(self):
         dice = DiceSet()
-        
+
         dice.roll(3)
         self.assertEqual(3, len(dice.values))
-        
+
         dice.roll(1)
         self.assertEqual(1, len(dice.values))

--- a/python2/koans/about_dictionaries.py
+++ b/python2/koans/about_dictionaries.py
@@ -14,31 +14,31 @@ class AboutDictionaries(Koan):
         self.assertEqual(dict, type(empty_dict))
         self.assertEqual(dict(), empty_dict)
         self.assertEqual(__, len(empty_dict))
-        
+
     def test_dictionary_literals(self):
         empty_dict = {}
         self.assertEqual(dict, type(empty_dict))
         babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish))
-        
+
     def test_accessing_dictionaries(self):
         babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, babel_fish['one'])
         self.assertEqual(__, babel_fish['two'])
-        
+
     def test_changing_dictionaries(self):
         babel_fish = {'one': 'uno', 'two': 'dos'}
         babel_fish['one'] = 'eins'
-        
+
         expected = {'two': 'dos', 'one': __}
         self.assertEqual(expected, babel_fish)
-        
+
     def test_dictionary_is_unordered(self):
         dict1 = {'one': 'uno', 'two': 'dos'}
         dict2 = {'two': 'dos', 'one': 'uno'}
-        
+
         self.assertEqual(____, dict1 == dict2)
-        
+
     def test_dictionary_keys_and_values(self):
         babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish.keys()))
@@ -53,7 +53,7 @@ class AboutDictionaries(Koan):
             ('red warrior', 'green elf', 'blue valkyrie', 'yellow dwarf',
              'confused looking zebra'),
             42)
-        
+
         self.assertEqual(__, len(cards))
         self.assertEqual(__, cards['green elf'])
         self.assertEqual(__, cards['yellow dwarf'])

--- a/python2/koans/about_exceptions.py
+++ b/python2/koans/about_exceptions.py
@@ -8,38 +8,38 @@ class AboutExceptions(Koan):
 
     class MySpecialError(RuntimeError):
         pass
-    
+
     def test_exceptions_inherit_from_exception(self):
         mro = self.MySpecialError.__mro__
         self.assertEqual(__, mro[1].__name__)
         self.assertEqual(__, mro[2].__name__)
         self.assertEqual(__, mro[3].__name__)
         self.assertEqual(__, mro[4].__name__)
-    
+
     def test_try_clause(self):
         result = None
         try:
             self.fail("Oops")
         except StandardError as ex:
             result = 'exception handled'
-        
+
         self.assertEqual(__, result)
-    
+
         self.assertEqual(____, isinstance(ex, StandardError))
         self.assertEqual(____, isinstance(ex, RuntimeError))
-    
+
         self.assertTrue(issubclass(RuntimeError, StandardError), \
             "RuntimeError is a subclass of StandardError")
-        
+
         self.assertEqual(__, ex[0])
-    
+
     def test_raising_a_specific_error(self):
         result = None
         try:
             raise self.MySpecialError, "My Message"
         except self.MySpecialError as ex:
             result = 'exception handled'
-  
+
         self.assertEqual(__, result)
         self.assertEqual(__, ex[0])
 
@@ -52,9 +52,9 @@ class AboutExceptions(Koan):
             pass
         else:
             result = 'no damage done'
-      
+
         self.assertEqual(__, result)
-    
+
     def test_finally_clause(self):
         result = None
         try:
@@ -64,5 +64,5 @@ class AboutExceptions(Koan):
             pass
         finally:
             result = 'always run'
-      
+
         self.assertEqual(__, result)

--- a/python2/koans/about_generators.py
+++ b/python2/koans/about_generators.py
@@ -12,7 +12,7 @@ from runner.koan import *
 
 
 class AboutGenerators(Koan):
-        
+
     def test_generating_values_on_the_fly(self):
         result = list()
         bacon_generator = (n + ' bacon' for \
@@ -20,16 +20,16 @@ class AboutGenerators(Koan):
         for bacon in bacon_generator:
             result.append(bacon)
         self.assertEqual(__, result)
-            
+
     def test_generators_are_different_to_list_comprehensions(self):
         num_list = [x * 2 for x in range(1, 3)]
         num_generator = (x * 2 for x in range(1, 3))
-        
+
         self.assertEqual(2, num_list[0])
-        
+
         # A generator has to be iterated through.
         self.assertEqual(__, list(num_generator)[0])
-        
+
         # Both list comprehensions and generators can be iterated
         # though. However, a generator function is only called on the
         # first iteration. The values are generated on the fly instead
@@ -42,18 +42,18 @@ class AboutGenerators(Koan):
 
         attempt1 = list(dynamite)
         attempt2 = list(dynamite)
-        
+
         self.assertEqual(__, list(attempt1))
         self.assertEqual(__, list(attempt2))
-    
+
     # ------------------------------------------------------------------
-    
+
     def simple_generator_method(self):
         yield 'peanut'
         yield 'butter'
         yield 'and'
         yield 'jelly'
-        
+
     def test_generator_method_will_yield_values_during_iteration(self):
         result = list()
         for item in self.simple_generator_method():
@@ -65,7 +65,7 @@ class AboutGenerators(Koan):
         self.assertEqual(__, next(result))
         self.assertEqual(__, next(result))
         result.close()
-        
+
     # ------------------------------------------------------------------
 
     def square_me(self, seq):
@@ -90,11 +90,11 @@ class AboutGenerators(Koan):
         self.assertEqual(__, list(result))
 
     # ------------------------------------------------------------------
-        
+
     def generator_with_coroutine(self):
         result = yield
         yield result
-    
+
     def test_generators_can_take_coroutines(self):
         generator = self.generator_with_coroutine()
 
@@ -116,26 +116,26 @@ class AboutGenerators(Koan):
             self.assertMatch(__, ex[0])
 
     # ------------------------------------------------------------------
-    
+
     def yield_tester(self):
         value = yield
         if value:
             yield value
         else:
             yield 'no value'
-    
+
     def test_generators_can_see_if_they_have_been_called_with_a_value(self):
         generator = self.yield_tester()
         next(generator)
         self.assertEqual('with value', generator.send('with value'))
-                         
+
         generator2 = self.yield_tester()
         next(generator2)
         self.assertEqual(__, next(generator2))
 
     def test_send_none_is_equivalent_to_next(self):
         generator = self.yield_tester()
-        
+
         next(generator)
         # 'next(generator)' is exactly equivalent to 'generator.send(None)'
         self.assertEqual(__, generator.send(None))

--- a/python2/koans/about_inheritance.py
+++ b/python2/koans/about_inheritance.py
@@ -12,70 +12,70 @@ class AboutInheritance(Koan):
         @property
         def name(self):
             return self._name
-            
+
         def bark(self):
             return "WOOF"
-  
+
     class Chihuahua(Dog):
         def wag(self):
             return "happy"
-    
+
         def bark(self):
             return "yip"
-  
+
     def test_subclasses_have_the_parent_as_an_ancestor(self):
         self.assertEqual(____, issubclass(self.Chihuahua, self.Dog))
-  
+
     def test_this_subclass_ultimately_inherits_from_object_class(self):
         self.assertEqual(____, issubclass(self.Chihuahua, object))
-                         
+
     def test_instances_inherit_behavior_from_parent_class(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.name)
-  
+
     def test_subclasses_add_new_behavior(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.wag())
-    
+
         try:
             fido = self.Dog("Fido")
             fido.wag()
         except StandardError as ex:
             self.assertMatch(__, ex[0])
-  
+
     def test_subclasses_can_modify_existing_behavior(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.bark())
-    
+
         fido = self.Dog("Fido")
         self.assertEqual(__, fido.bark())
-  
+
     # ------------------------------------------------------------------
-  
+
     class BullDog(Dog):
         def bark(self):
             return super(AboutInheritance.BullDog, self).bark() + ", GRR"
-  
+
     def test_subclasses_can_invoke_parent_behavior_via_super(self):
         ralph = self.BullDog("Ralph")
         self.assertEqual(__, ralph.bark())
-  
+
     # ------------------------------------------------------------------
-  
+
     class GreatDane(Dog):
         def growl(self):
             return super(AboutInheritance.GreatDane, self).bark() + ", GROWL"
-  
+
     def test_super_works_across_methods(self):
         george = self.GreatDane("George")
         self.assertEqual(__, george.growl())
 
     # ---------------------------------------------------------
-    
+
     class Pug(Dog):
         def __init__(self, name):
             pass
-        
+
     class Greyhound(Dog):
         def __init__(self, name):
             super(AboutInheritance.Greyhound, self).__init__(name)
@@ -86,7 +86,7 @@ class AboutInheritance(Koan):
             name = snoopy.name
         except Exception as ex:
             self.assertMatch(__, ex[0])
-        
+
     def test_base_init_has_to_be_called_explicitly(self):
         boxer = self.Greyhound("Boxer")
         self.assertEqual(__, boxer.name)

--- a/python2/koans/about_iteration.py
+++ b/python2/koans/about_iteration.py
@@ -8,12 +8,12 @@ class AboutIteration(Koan):
 
     def test_iterators_are_a_type(self):
         it = iter(range(1, 6))
-        
+
         fib = 0
-        
+
         for num in it:
             fib += num
-            
+
         self.assertEqual(__, fib)
 
     def test_iterating_with_next(self):
@@ -26,7 +26,7 @@ class AboutIteration(Koan):
             next(stages)
         except StopIteration as ex:
             err_msg = 'Ran out of iterations'
-            
+
         self.assertMatch(__, err_msg)
 
     # ------------------------------------------------------------------
@@ -36,29 +36,29 @@ class AboutIteration(Koan):
 
     def test_map_transforms_elements_of_a_list(self):
         seq = [1, 2, 3]
-   
+
         mapped_seq = map(self.add_ten, seq)
         self.assertEqual(__, mapped_seq)
-        
+
     def test_filter_selects_certain_items_from_a_list(self):
         def is_even(item):
             return (item % 2) == 0
 
         seq = [1, 2, 3, 4, 5, 6]
-   
+
         even_numbers = filter(is_even, seq)
         self.assertEqual(__, even_numbers)
-    
+
     def test_just_return_first_item_found(self):
         def is_big_name(item):
             return len(item) > 4
-        
+
         names = ["Jim", "Bill", "Clarence", "Doug", "Eli"]
-    
+
         # NOTE This still iterates through the whole names, so not particularly
         # efficient
         self.assertEqual([__], filter(is_big_name, names)[:1])
-        
+
         # Boring but effective
         for item in names:
             if is_big_name(item):
@@ -72,36 +72,36 @@ class AboutIteration(Koan):
 
     def multiply(self, accum, item):
         return accum * item
-        
+
     def test_reduce_will_blow_your_mind(self):
         result = reduce(self.add, [2, 3, 4])
         self.assertEqual(__, result)
-    
+
         result2 = reduce(self.multiply, [2, 3, 4], 1)
         self.assertEqual(__, result2)
-    
+
         # Extra Credit:
         # Describe in your own words what reduce does.
-    
+
     # ------------------------------------------------------------------
 
     def test_creating_lists_with_list_comprehensions(self):
         feast = ['lambs', 'sloths', 'orangutans', 'breakfast cereals',
             'fruit bats']
-        
+
         comprehension = [delicacy.capitalize() for delicacy in feast]
-        
+
         self.assertEqual(__, comprehension[0])
         self.assertEqual(__, comprehension[2])
-        
+
     def test_use_pass_for_iterations_with_no_body(self):
         for num in range(1, 5):
             pass
-                
+
         self.assertEqual(__, num)
-        
+
     # ------------------------------------------------------------------
-        
+
     def test_all_iteration_methods_work_on_any_sequence_not_just_lists(self):
         # Ranges are an iteratable sequence
         result = map(self.add_ten, range(1, 4))
@@ -110,7 +110,7 @@ class AboutIteration(Koan):
         try:
             f = open("example_file.txt")
 
-            try:   
+            try:
                 def make_upcase(line):
                     return line.strip().upper()
                 upcase_lines = map(make_upcase, f.readlines())

--- a/python2/koans/about_lambdas.py
+++ b/python2/koans/about_lambdas.py
@@ -14,14 +14,14 @@ class AboutLambdas(Koan):
         self.assertEqual(__, add_one(10))
 
     # ------------------------------------------------------------------
-    
+
     def make_order(self, order):
         return lambda qty: str(qty) + " " + order + "s"
-            
+
     def test_accessing_lambda_via_assignment(self):
         sausages = self.make_order('sausage')
         eggs = self.make_order('egg')
-        
+
         self.assertEqual(__, sausages(3))
         self.assertEqual(__, eggs(2))
 

--- a/python2/koans/about_list_assignments.py
+++ b/python2/koans/about_list_assignments.py
@@ -12,17 +12,17 @@ class AboutListAssignments(Koan):
     def test_non_parallel_assignment(self):
         names = ["John", "Smith"]
         self.assertEqual(__, names)
-        
+
     def test_parallel_assignments(self):
         first_name, last_name = ["John", "Smith"]
         self.assertEqual(__, first_name)
         self.assertEqual(__, last_name)
-                        
+
     def test_parallel_assignments_with_sublists(self):
         first_name, last_name = [["Willie", "Rae"], "Johnson"]
         self.assertEqual(__, first_name)
         self.assertEqual(__, last_name)
-                
+
     def test_swapping_with_parallel_assignment(self):
         first_name = "Roy"
         last_name = "Rob"

--- a/python2/koans/about_lists.py
+++ b/python2/koans/about_lists.py
@@ -17,27 +17,27 @@ class AboutLists(Koan):
     def test_list_literals(self):
         nums = list()
         self.assertEqual([], nums)
-        
+
         nums[0:] = [1]
         self.assertEqual([1], nums)
-        
+
         nums[1:] = [2]
         self.assertEqual([1, __], nums)
-        
+
         nums.append(333)
         self.assertEqual([1, 2, __], nums)
-    
+
     def test_accessing_list_elements(self):
         noms = ['peanut', 'butter', 'and', 'jelly']
-        
+
         self.assertEqual(__, noms[0])
         self.assertEqual(__, noms[3])
         self.assertEqual(__, noms[-1])
         self.assertEqual(__, noms[-3])
-    
+
     def test_slicing_lists(self):
         noms = ['peanut', 'butter', 'and', 'jelly']
-        
+
         self.assertEqual(__, noms[0:1])
         self.assertEqual(__, noms[0:2])
         self.assertEqual(__, noms[2:2])
@@ -51,7 +51,7 @@ class AboutLists(Koan):
 
         self.assertEqual(__, noms[2:])
         self.assertEqual(__, noms[:2])
-    
+
     def test_lists_and_ranges(self):
         self.assertEqual(list, type(range(5)))
         self.assertEqual(__, range(5))
@@ -70,37 +70,37 @@ class AboutLists(Koan):
 
         knight.insert(0, 'Arthur')
         self.assertEqual(__, knight)
-            
+
     def test_popping_lists(self):
         stack = [10, 20, 30, 40]
         stack.append('last')
-        
+
         self.assertEqual(__, stack)
-        
+
         popped_value = stack.pop()
         self.assertEqual(__, popped_value)
         self.assertEqual(__, stack)
-        
+
         popped_value = stack.pop(1)
         self.assertEqual(__, popped_value)
         self.assertEqual(__, stack)
-        
+
         # Notice that there is a "pop" but no "push" in python?
-        
+
         # Part of the Python philosophy is that there ideally should be one and
         # only one way of doing anything. A 'push' is the same as an 'append'.
-        
+
         # To learn more about this try typing "import this" from the python
         # console... ;)
-        
+
     def test_use_deques_for_making_queues(self):
         from collections import deque
 
         queue = deque([1, 2])
         queue.append('last')
-        
+
         self.assertEqual(__, list(queue))
-        
+
         popped_value = queue.popleft()
         self.assertEqual(__, popped_value)
         self.assertEqual(__, list(queue))

--- a/python2/koans/about_method_bindings.py
+++ b/python2/koans/about_method_bindings.py
@@ -30,7 +30,7 @@ class AboutMethodBindings(Koan):
     def test_functions_have_attributes(self):
         self.assertEqual(__, len(dir(function)))
         self.assertEqual(__, dir(function) == dir(Class.method.im_func))
-        
+
     def test_bound_methods_have_different_attributes(self):
         obj = Class()
         self.assertEqual(__, len(dir(obj.method)))
@@ -45,12 +45,12 @@ class AboutMethodBindings(Koan):
             obj.method.cherries = 3
         except AttributeError as ex:
             self.assertMatch(__, ex[0])
- 
+
     def test_setting_attributes_on_methods_by_accessing_the_inner_function(self):
         obj = Class()
         obj.method.im_func.cherries = 3
         self.assertEqual(__, obj.method.cherries)
-        
+
     def test_functions_can_have_inner_functions(self):
         function2.get_fruit = function
         self.assertEqual(__, function2.get_fruit())
@@ -69,7 +69,7 @@ class AboutMethodBindings(Koan):
             return (self, obj, cls)
 
     binding = BoundClass()
-            
+
     def test_get_descriptor_resolves_attribute_binding(self):
         bound_obj, binding_owner, owner_type = self.binding
         # Look at BoundClass.__get__():
@@ -91,7 +91,7 @@ class AboutMethodBindings(Koan):
             self.choice = val
 
     color = SuperColor()
-            
+
     def test_set_descriptor_changes_behavior_of_attribute_assignment(self):
         self.assertEqual(None, self.color.choice)
         self.color = 'purple'

--- a/python2/koans/about_methods.py
+++ b/python2/koans/about_methods.py
@@ -15,7 +15,7 @@ def my_global_function(a, b):
 class AboutMethods(Koan):
     def test_calling_a_global_function(self):
         self.assertEqual(__, my_global_function(2, 3))
-  
+
     # NOTE: Wrong number of arguments is not a SYNTAX error, but a
     # runtime error.
     def test_calling_functions_with_wrong_number_of_arguments(self):
@@ -26,16 +26,16 @@ class AboutMethods(Koan):
             self.assertMatch(
                 r'my_global_function\(\) takes exactly 2 arguments \(0 given\)',
                 exception[0])
-        
+
         try:
             my_global_function(1, 2, 3)
         except Exception as e:
-            
+
             # Note, watch out for parenthesis. They need slashes in front!
             self.assertMatch(__, e[0])
-    
+
     # ------------------------------------------------------------------
-    
+
     def pointless_method(self, a, b):
         sum = a + b
 
@@ -43,7 +43,7 @@ class AboutMethods(Koan):
         self.assertEqual(__, self.pointless_method(1, 2))
         # Notice that methods accessed from class scope do not require
         # you to pass the first "self" argument?
-        
+
     # ------------------------------------------------------------------
 
     def method_with_defaults(self, a, b='default_value'):
@@ -67,13 +67,13 @@ class AboutMethods(Koan):
 
     def function_with_the_same_name(self, a, b):
         return a + b
-    
+
     def test_functions_without_self_arg_are_global_functions(self):
         def function_with_the_same_name(a, b):
             return a * b
 
         self.assertEqual(__, function_with_the_same_name(3, 4))
-    
+
     def test_calling_methods_in_same_class_with_explicit_receiver(self):
         def function_with_the_same_name(a, b):
             return a * b
@@ -84,9 +84,9 @@ class AboutMethods(Koan):
 
     def another_method_with_the_same_name(self):
         return 10
-    
+
     link_to_overlapped_method = another_method_with_the_same_name
-    
+
     def another_method_with_the_same_name(self):
         return 42
 
@@ -114,7 +114,7 @@ class AboutMethods(Koan):
     # ------------------------------------------------------------------
 
     def one_line_method(self): return 'Madagascar'
-        
+
     def test_no_indentation_required_for_one_line_statement_bodies(self):
         self.assertEqual(__, self.one_line_method())
 
@@ -123,7 +123,7 @@ class AboutMethods(Koan):
     def method_with_documentation(self):
         "A string placed at the beginning of a function is used for documentation"
         return "ok"
-    
+
     def test_the_documentation_can_be_viewed_with_the_doc_method(self):
         self.assertMatch(__, self.method_with_documentation.__doc__)
 
@@ -132,7 +132,7 @@ class AboutMethods(Koan):
     class Dog(object):
         def name(self):
             return "Fido"
-        
+
         def _tail(self):
             # Prefixing a method with an underscore implies private scope
             return "wagging"
@@ -143,7 +143,7 @@ class AboutMethods(Koan):
     def test_calling_methods_in_other_objects(self):
         rover = self.Dog()
         self.assertEqual(__, rover.name())
-        
+
     def test_private_access_is_implied_but_not_enforced(self):
         rover = self.Dog()
 
@@ -159,9 +159,9 @@ class AboutMethods(Koan):
             password = rover.__password()
         except Exception as ex:
             self.assertEqual(__, type(ex).__name__)
-        
+
         # But this still is!
         self.assertEqual(__, rover._Dog__password())
-        
+
         # Name mangling exists to avoid name clash issues when subclassing.
         # It is not for providing effective access protection

--- a/python2/koans/about_modules.py
+++ b/python2/koans/about_modules.py
@@ -15,19 +15,19 @@ from local_module_with_all_defined import *
 class AboutModules(Koan):
     def test_importing_other_python_scripts_as_modules(self):
         import local_module  # local_module.py
-        
+
         duck = local_module.Duck()
         self.assertEqual(__, duck.name)
-        
+
     def test_importing_attributes_from_classes_using_from_keyword(self):
         from local_module import Duck
-        
+
         duck = Duck()  # no module qualifier needed this time
         self.assertEqual(__, duck.name)
 
     def test_we_can_import_multiple_items_at_once(self):
         import jims, joes
-        
+
         jims_dog = jims.Dog()
         joes_dog = joes.Dog()
         self.assertEqual(__, jims_dog.identify())
@@ -39,13 +39,13 @@ class AboutModules(Koan):
             from another_local_module import *
         The import wildcard cannot be used from within classes or functions.
         """
-                                        
+
         goose = Goose()
         hamster = Hamster()
-        
+
         self.assertEqual(__, goose.name)
         self.assertEqual(__, hamster.name)
-        
+
     def test_modules_hide_attributes_prefixed_by_underscores(self):
         try:
             private_squirrel = _SecretSquirrel()
@@ -54,12 +54,12 @@ class AboutModules(Koan):
 
     def test_private_attributes_are_still_accessible_in_modules(self):
         from local_module import Duck  # local_module.py
-        
+
         duck = Duck()
         self.assertEqual(__, duck._password)
         # module level attribute hiding doesn't affect class attributes
         # (unless the class itself is hidden).
-            
+
     def test_a_modules_XallX_statement_limits_what_wildcards_will_match(self):
         """Examine results of from local_module_with_all_defined import *"""
 
@@ -70,7 +70,7 @@ class AboutModules(Koan):
         # How about velociraptors?
         lizard = _Velociraptor()
         self.assertEqual(__, lizard.name)
-        
+
         # SecretDuck? Never heard of her!
         try:
             duck = SecretDuck()

--- a/python2/koans/about_monkey_patching.py
+++ b/python2/koans/about_monkey_patching.py
@@ -12,13 +12,13 @@ class AboutMonkeyPatching(Koan):
     class Dog(object):
         def bark(self):
             return "WOOF"
-    
+
     def test_as_defined_dogs_do_bark(self):
         fido = self.Dog()
         self.assertEqual(__, fido.bark())
 
     # ------------------------------------------------------------------
-    
+
     # Add a new method to an existing class.
     def test_after_patching_dogs_can_both_wag_and_bark(self):
         def wag(self):
@@ -29,9 +29,9 @@ class AboutMonkeyPatching(Koan):
         fido = self.Dog()
         self.assertEqual(__, fido.wag())
         self.assertEqual(__, fido.bark())
-    
+
     # ------------------------------------------------------------------
-    
+
     def test_most_built_in_classes_cannot_be_monkey_patched(self):
         try:
             int.is_even = lambda self: (self % 2) == 0
@@ -42,9 +42,9 @@ class AboutMonkeyPatching(Koan):
 
     class MyInt(int):
         pass
-    
+
     def test_subclasses_of_built_in_classes_can_be_be_monkey_patched(self):
         self.MyInt.is_even = lambda self: (self % 2) == 0
-    
+
         self.assertEqual(____, self.MyInt(1).is_even())
         self.assertEqual(____, self.MyInt(2).is_even())

--- a/python2/koans/about_new_style_classes.py
+++ b/python2/koans/about_new_style_classes.py
@@ -8,7 +8,7 @@ class AboutNewStyleClasses(Koan):
     class OldStyleClass:
         "An old style class"
         # Original class style have been phased out in Python 3.
-        
+
     class NewStyleClass(object):
         "A new style class"
         # Introduced in Python 2.2
@@ -20,12 +20,12 @@ class AboutNewStyleClasses(Koan):
     def test_new_style_classes_inherit_from_object_base_class(self):
         self.assertEqual(____, issubclass(self.NewStyleClass, object))
         self.assertEqual(____, issubclass(self.OldStyleClass, object))
-        
+
     def test_new_style_classes_have_more_attributes(self):
         self.assertEqual(__, len(dir(self.OldStyleClass)))
         self.assertEqual(__, self.OldStyleClass.__doc__)
         self.assertEqual(__, self.OldStyleClass.__module__)
-    
+
         self.assertEqual(__, len(dir(self.NewStyleClass)))
         # To examine the available attributes, run
         # 'dir(<Class name goes here>)'
@@ -35,23 +35,23 @@ class AboutNewStyleClasses(Koan):
 
     def test_old_style_classes_have_type_but_no_class_attribute(self):
         self.assertEqual(__, type(self.OldStyleClass).__name__)
-        
+
         try:
             cls = self.OldStyleClass.__class__
         except Exception as ex:
             pass
-        
+
         self.assertMatch(__, ex[0])
-    
+
     def test_new_style_classes_have_same_class_as_type(self):
         new_style = self.NewStyleClass()
         self.assertEqual(__, type(self.NewStyleClass).__name__)
         self.assertEqual(
             __,
             type(self.NewStyleClass) == self.NewStyleClass.__class__)
-        
+
     # ------------------------------------------------------------------
-        
+
     def test_in_old_style_instances_class_is_different_to_type(self):
         old_style = self.OldStyleClass()
         self.assertEqual(__, type(old_style).__name__)

--- a/python2/koans/about_none.py
+++ b/python2/koans/about_none.py
@@ -13,7 +13,7 @@ class AboutNone(Koan):
     def test_none_is_an_object(self):
         "Unlike NULL in a lot of languages"
         self.assertEqual(__, isinstance(None, object))
-   
+
     def test_none_is_universal(self):
         "There is only one None"
         self.assertEqual(__, None is None)
@@ -22,10 +22,10 @@ class AboutNone(Koan):
         """
         What is the Exception that is thrown when you call a method that does
         not exist?
-        
+
         Hint: launch python command console and try the code in the
         block below.
-        
+
         Don't worry about what 'try' and 'except' do, we'll talk about
         this later
         """
@@ -34,11 +34,11 @@ class AboutNone(Koan):
         except Exception as ex:
             # What exception has been caught?
             self.assertEqual(__, ex.__class__.__name__)
-            
+
             # What message was attached to the exception?
             # (HINT: replace __ with part of the error message.)
             self.assertMatch(__, ex.args[0])
-    
+
     def test_none_is_distinct(self):
         """
         None is distinct from other things which are False.

--- a/python2/koans/about_packages.py
+++ b/python2/koans/about_packages.py
@@ -28,16 +28,16 @@ class AboutPackages(Koan):
     def test_subfolders_can_form_part_of_a_module_package(self):
         # Import ./a_package_folder/a_module.py
         from a_package_folder.a_module import Duck
-        
+
         duck = Duck()
         self.assertEqual(__, duck.name)
-        
+
     def test_subfolders_become_modules_if_they_have_an_init_module(self):
         # Import ./a_package_folder/__init__.py
         from a_package_folder import an_attribute
-        
+
         self.assertEqual(__, an_attribute)
-        
+
     def test_subfolders_without_an_init_module_are_not_part_of_the_package(self):
         # Import ./a_normal_folder/
         try:
@@ -52,7 +52,7 @@ class AboutPackages(Koan):
         import contemplate_koans
 
         self.assertEqual(__, contemplate_koans.__name__)
-        
+
         # contemplate_koans.py is the root module in this package because its
         # the first python module called in koans.
         #

--- a/python2/koans/about_proxy_object_project.py
+++ b/python2/koans/about_proxy_object_project.py
@@ -22,7 +22,7 @@ from runner.koan import *
 class Proxy(object):
     def __init__(self, target_object):
         # WRITE CODE HERE
-        
+
         #initialize '_obj' attribute last. Trust me on this!
         self._obj = target_object
 
@@ -35,29 +35,29 @@ class AboutProxyObjectProject(Koan):
     def test_proxy_method_returns_wrapped_object(self):
         # NOTE: The Television class is defined below
         tv = Proxy(Television())
-        
+
         self.assertTrue(isinstance(tv, Proxy))
-    
+
     def test_tv_methods_still_perform_their_function(self):
         tv = Proxy(Television())
-        
+
         tv.channel = 10
         tv.power()
-        
+
         self.assertEqual(10, tv.channel)
         self.assertTrue(tv.is_on())
-    
+
     def test_proxy_records_messages_sent_to_tv(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.channel = 10
-        
+
         self.assertEqual(['power', 'channel'], tv.messages())
-    
+
     def test_proxy_handles_invalid_messages(self):
         tv = Proxy(Television())
-        
+
         ex = None
         try:
             tv.no_such_method()
@@ -65,34 +65,34 @@ class AboutProxyObjectProject(Koan):
             pass
 
         self.assertEqual(AttributeError, type(ex))
-        
+
     def test_proxy_reports_methods_have_been_called(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.power()
-        
+
         self.assertTrue(tv.was_called('power'))
         self.assertFalse(tv.was_called('channel'))
-    
+
     def test_proxy_counts_method_calls(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.channel = 48
         tv.power()
-      
+
         self.assertEqual(2, tv.number_of_times_called('power'))
         self.assertEqual(1, tv.number_of_times_called('channel'))
         self.assertEqual(0, tv.number_of_times_called('is_on'))
-    
+
     def test_proxy_can_record_more_than_just_tv_objects(self):
         proxy = Proxy("Py Ohio 2010")
-      
+
         result = proxy.upper()
 
         self.assertEqual("PY OHIO 2010", result)
-        
+
         result = proxy.split()
 
         self.assertEqual(["Py", "Ohio", "2010"], result)
@@ -108,7 +108,7 @@ class Television(object):
     def __init__(self):
         self._channel = None
         self._power = None
-        
+
     @property
     def channel(self):
         return self._channel
@@ -116,13 +116,13 @@ class Television(object):
     @channel.setter
     def channel(self, value):
         self._channel = value
-        
+
     def power(self):
         if self._power == 'on':
             self._power = 'off'
         else:
             self._power = 'on'
-    
+
     def is_on(self):
         return self._power == 'on'
 
@@ -131,33 +131,33 @@ class Television(object):
 class TelevisionTest(Koan):
     def test_it_turns_on(self):
         tv = Television()
-        
+
         tv.power()
         self.assertTrue(tv.is_on())
-    
+
     def test_it_also_turns_off(self):
         tv = Television()
-        
+
         tv.power()
         tv.power()
-        
+
         self.assertFalse(tv.is_on())
-    
+
     def test_edge_case_on_off(self):
         tv = Television()
-        
+
         tv.power()
         tv.power()
         tv.power()
-            
+
         self.assertTrue(tv.is_on())
-        
+
         tv.power()
-        
+
         self.assertFalse(tv.is_on())
-  
+
     def test_can_set_the_channel(self):
         tv = Television()
-    
+
         tv.channel = 11
         self.assertEqual(11, tv.channel)

--- a/python2/koans/about_scope.py
+++ b/python2/koans/about_scope.py
@@ -15,42 +15,42 @@ class AboutScope(Koan):
     #   Look in jims.py and joes.py to see definitions of Dog used
     #   for this set of tests
     #
-    
+
     def test_dog_is_not_available_in_the_current_scope(self):
         try:
             fido = Dog()
         except Exception as ex:
             self.assertMatch(__, ex[0])
-  
+
     def test_you_can_reference_nested_classes_using_the_scope_operator(self):
         fido = jims.Dog()
         # name 'jims' module name is taken from jim.py filename
-        
+
         rover = joes.Dog()
         self.assertEqual(__, fido.identify())
         self.assertEqual(__, rover.identify())
-        
+
         self.assertEqual(____, type(fido) == type(rover))
         self.assertEqual(____, jims.Dog == joes.Dog)
-  
+
     # ------------------------------------------------------------------
-  
+
     class str(object):
         pass
-    
+
     def test_bare_bones_class_names_do_not_assume_the_current_scope(self):
         self.assertEqual(____, AboutScope.str == str)
-    
+
     def test_nested_string_is_not_the_same_as_the_system_string(self):
         self.assertEqual(____, self.str == type("HI"))
-    
+
     def test_str_without_self_prefix_stays_in_the_global_scope(self):
         self.assertEqual(____, str == type("HI"))
 
     # ------------------------------------------------------------------
 
     PI = 3.1416
-  
+
     def test_constants_are_defined_with_an_initial_uppercase_letter(self):
         self.assertAlmostEqual(_____, self.PI)
         # Note, floating point numbers in python are not precise.
@@ -66,11 +66,11 @@ class AboutScope(Koan):
 
     def increment_using_local_counter(self, counter):
         counter = counter + 1
-       
+
     def increment_using_global_counter(self):
         global counter
         counter = counter + 1
-    
+
     def test_incrementing_with_local_counter(self):
         global counter
         start = counter
@@ -82,11 +82,11 @@ class AboutScope(Koan):
         start = counter
         self.increment_using_global_counter()
         self.assertEqual(____, counter == start + 1)
-    
+
     # ------------------------------------------------------------------
-    
+
     global deadly_bingo
     deadly_bingo = [4, 8, 15, 16, 23, 42]
-    
+
     def test_global_attributes_can_be_created_in_the_middle_of_a_class(self):
         self.assertEqual(__, deadly_bingo[5])

--- a/python2/koans/about_scoring_project.py
+++ b/python2/koans/about_scoring_project.py
@@ -41,34 +41,34 @@ def score(dice):
 class AboutScoringProject(Koan):
     def test_score_of_an_empty_list_is_zero(self):
         self.assertEqual(0, score([]))
-    
+
     def test_score_of_a_single_roll_of_5_is_50(self):
         self.assertEqual(50, score([5]))
-    
+
     def test_score_of_a_single_roll_of_1_is_100(self):
         self.assertEqual(100, score([1]))
-    
+
     def test_score_of_multiple_1s_and_5s_is_the_sum_of_individual_scores(self):
         self.assertEqual(300, score([1, 5, 5, 1]))
-    
+
     def test_score_of_single_2s_3s_4s_and_6s_are_zero(self):
         self.assertEqual(0, score([2, 3, 4, 6]))
-    
+
     def test_score_of_a_triple_1_is_1000(self):
         self.assertEqual(1000, score([1, 1, 1]))
-    
+
     def test_score_of_other_triples_is_100x(self):
         self.assertEqual(200, score([2, 2, 2]))
         self.assertEqual(300, score([3, 3, 3]))
         self.assertEqual(400, score([4, 4, 4]))
         self.assertEqual(500, score([5, 5, 5]))
         self.assertEqual(600, score([6, 6, 6]))
-    
+
     def test_score_of_mixed_is_sum(self):
         self.assertEqual(250, score([2, 5, 2, 2, 3]))
         self.assertEqual(550, score([5, 5, 5, 5]))
         self.assertEqual(1150, score([1, 1, 1, 5, 1]))
-        
+
     def test_ones_not_left_out(self):
         self.assertEqual(300, score([1, 2, 2, 2]))
         self.assertEqual(350, score([1, 5, 2, 2, 2]))

--- a/python2/koans/about_strings.py
+++ b/python2/koans/about_strings.py
@@ -5,15 +5,15 @@ from runner.koan import *
 
 
 class AboutStrings(Koan):
-    
+
     def test_double_quoted_strings_are_strings(self):
         string = "Hello, world."
         self.assertEqual(__, isinstance(string, basestring))
-    
+
     def test_single_quoted_strings_are_also_strings(self):
         string = 'Goodbye, world.'
         self.assertEqual(__, isinstance(string, basestring))
-    
+
     def test_triple_quote_strings_are_also_strings(self):
         string = """Howdy, world!"""
         self.assertEqual(__, isinstance(string, basestring))
@@ -25,15 +25,15 @@ class AboutStrings(Koan):
     def test_raw_strings_are_also_strings(self):
         string = r"Konnichi wa, world!"
         self.assertEqual(__, isinstance(string, basestring))
-        
+
     def test_use_single_quotes_to_create_string_with_double_quotes(self):
         string = 'He said, "Go Away."'
         self.assertEqual(__, string)
-  
+
     def test_use_double_quotes_to_create_strings_with_single_quotes(self):
         string = "Don't"
         self.assertEqual(__, string)
-    
+
     def test_use_backslash_for_escaping_quotes_in_strings(self):
         a = "He said, \"Don't\""
         b = 'He said, "Don\'t"'
@@ -43,22 +43,22 @@ class AboutStrings(Koan):
         string = "It was the best of times,\n\
 It was the worst of times."
         self.assertEqual(__, len(string))
-        
+
     def test_triple_quoted_strings_can_span_lines(self):
         string = """
 Howdy,
 world!
 """
         self.assertEqual(__, len(string))
-    
+
     def test_triple_quoted_strings_need_less_escaping(self):
         a = "Hello \"world\"."
         b = """Hello "world"."""
         self.assertEqual(__, (a == b))
-    
+
     def but_quotes_at_the_end_of_a_triple_quoted_string_are_still_tricky(self):
         string = """Hello "world\""""
-    
+
     def test_plus_concatenates_strings(self):
         string = "Hello, " + "world"
         self.assertEqual(__, string)
@@ -66,20 +66,20 @@ world!
     def test_adjacent_strings_are_concatenated_automatically(self):
         string = "Hello" ", " "world"
         self.assertEqual(__, string)
-    
+
     def test_plus_will_not_modify_original_strings(self):
         hi = "Hello, "
         there = "world"
         string = hi + there
         self.assertEqual(__, hi)
         self.assertEqual(__, there)
-    
+
     def test_plus_equals_will_append_to_end_of_string(self):
         hi = "Hello, "
         there = "world"
         hi += there
         self.assertEqual(__, hi)
-    
+
     def test_plus_equals_also_leaves_original_string_unmodified(self):
         original = "Hello, "
         hi = original
@@ -92,7 +92,7 @@ world!
         self.assertEqual('\n', string)
         self.assertEqual("""\n""", string)
         self.assertEqual(__, len(string))
-    
+
     def test_use_format_to_interpolate_variables(self):
         value1 = 'one'
         value2 = 2
@@ -104,42 +104,42 @@ world!
         value2 = 'DOH'
         string = "The values are {1}, {0}, {0} and {1}!".format(value1, value2)
         self.assertEqual(__, string)
-    
+
     def test_any_python_expression_may_be_interpolated(self):
         import math  # import a standard python module with math functions
-        
+
         decimal_places = 4
         string = "The square root of 5 is {0:.{1}f}".format(math.sqrt(5), \
             decimal_places)
         self.assertEqual(__, string)
-    
+
     def test_you_can_get_a_substring_from_a_string(self):
         string = "Bacon, lettuce and tomato"
         self.assertEqual(__, string[7:10])
-    
+
     def test_you_can_get_a_single_character_from_a_string(self):
         string = "Bacon, lettuce and tomato"
         self.assertEqual(__, string[1])
-    
+
     def test_single_characters_can_be_represented_by_integers(self):
         self.assertEqual(__, ord('a'))
         self.assertEqual(__, ord('b') == (ord('a') + 1))
-    
+
     def test_strings_can_be_split(self):
         string = "Sausage Egg Cheese"
         words = string.split()
         self.assertEqual([__, __, __], words)
-    
+
     def test_strings_can_be_split_with_different_patterns(self):
         import re  # import python regular expression library
-        
+
         string = "the,rain;in,spain"
         pattern = re.compile(',|;')
-        
+
         words = pattern.split(string)
-        
+
         self.assertEqual([__, __, __, __], words)
-        
+
         # `pattern` is a Python regular expression pattern which matches
         # ',' or ';'
 
@@ -150,7 +150,7 @@ world!
         self.assertEqual(__, len(string))
 
         # Useful in regular expressions, file paths, URLs, etc.
-                    
+
     def test_strings_can_be_joined(self):
         words = ["Now", "is", "the", "time"]
         self.assertEqual(__, ' '.join(words))

--- a/python2/koans/about_triangle_project.py
+++ b/python2/koans/about_triangle_project.py
@@ -11,13 +11,13 @@ class AboutTriangleProject(Koan):
     def test_equilateral_triangles_have_equal_sides(self):
         self.assertEqual('equilateral', triangle(2, 2, 2))
         self.assertEqual('equilateral', triangle(10, 10, 10))
-  
+
     def test_isosceles_triangles_have_exactly_two_sides_equal(self):
         self.assertEqual('isosceles', triangle(3, 4, 4))
         self.assertEqual('isosceles', triangle(4, 3, 4))
         self.assertEqual('isosceles', triangle(4, 4, 3))
         self.assertEqual('isosceles', triangle(10, 10, 2))
-  
+
     def test_scalene_triangles_have_no_equal_sides(self):
         self.assertEqual('scalene', triangle(3, 4, 5))
         self.assertEqual('scalene', triangle(10, 11, 12))

--- a/python2/koans/about_triangle_project2.py
+++ b/python2/koans/about_triangle_project2.py
@@ -13,7 +13,7 @@ class AboutTriangleProject2(Koan):
     def test_illegal_triangles_throw_exceptions(self):
         # Calls triangle(0, 0, 0)
         self.assertRaises(TriangleError, triangle, 0, 0, 0)
-        
+
         self.assertRaises(TriangleError, triangle, 3, 4, -5)
         self.assertRaises(TriangleError, triangle, 1, 1, 3)
         self.assertRaises(TriangleError, triangle, 2, 4, 2)

--- a/python2/koans/about_true_and_false.py
+++ b/python2/koans/about_true_and_false.py
@@ -10,13 +10,13 @@ class AboutTrueAndFalse(Koan):
             return 'true stuff'
         else:
             return 'false stuff'
-        
+
     def test_true_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(True))
-        
+
     def test_false_is_treated_as_false(self):
         self.assertEqual(__, self.truth_value(False))
-        
+
     def test_none_is_treated_as_false(self):
         self.assertEqual(__, self.truth_value(None))
 
@@ -31,7 +31,7 @@ class AboutTrueAndFalse(Koan):
 
     def test_blank_strings_are_treated_as_false(self):
         self.assertEqual(__, self.truth_value(""))
-        
+
     def test_everything_else_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(1))
         self.assertEqual(__, self.truth_value(1,))

--- a/python2/koans/about_tuples.py
+++ b/python2/koans/about_tuples.py
@@ -8,48 +8,48 @@ class AboutTuples(Koan):
     def test_creating_a_tuple(self):
         count_of_three = (1, 2, 5)
         self.assertEqual(__, count_of_three[2])
-        
+
     def test_tuples_are_immutable_so_item_assignment_is_not_possible(self):
         count_of_three = (1, 2, 5)
         try:
             count_of_three[2] = "three"
         except TypeError as ex:
             self.assertMatch(__, ex[0])
-        
+
     def test_tuples_are_immutable_so_appending_is_not_possible(self):
         count_of_three = (1, 2, 5)
         try:
             count_of_three.append("boom")
         except Exception as ex:
             self.assertEqual(AttributeError, type(ex))
-            
+
             # Note, assertMatch() uses regular expression pattern matching,
             # so you don't have to copy the whole message.
             self.assertMatch(__, ex[0])
-        
+
         # Tuples are less flexible than lists, but faster.
 
     def test_tuples_can_only_be_changed_through_replacement(self):
         count_of_three = (1, 2, 5)
-        
+
         list_count = list(count_of_three)
         list_count.append("boom")
         count_of_three = tuple(list_count)
-        
+
         self.assertEqual(__, count_of_three)
 
     def test_tuples_of_one_look_peculiar(self):
         self.assertEqual(__, (1).__class__.__name__)
         self.assertEqual(__, (1,).__class__.__name__)
         self.assertEqual(__, ("Hello comma!", ))
-        
+
     def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))
 
     def test_creating_empty_tuples(self):
         self.assertEqual(__, ())
         self.assertEqual(__, tuple())  # Sometimes less confusing
-        
+
     def test_tuples_can_be_embedded(self):
         lat = (37, 14, 6, 'N')
         lon = (115, 48, 40, 'W')
@@ -61,10 +61,10 @@ class AboutTuples(Koan):
             ("Illuminati HQ", (38, 52, 15.56, 'N'), (77, 3, 21.46, 'W')),
             ("Stargate B", (41, 10, 43.92, 'N'), (1, 49, 34.29, 'W')),
         ]
-        
-        locations.append( 
+
+        locations.append(
             ("Cthulhu", (26, 40, 1, 'N'), (70, 45, 7, 'W'))
         )
-        
+
         self.assertEqual(__, locations[2][0])
         self.assertEqual(__, locations[0][1][2])

--- a/python2/koans/about_with_statements.py
+++ b/python2/koans/about_with_statements.py
@@ -24,12 +24,12 @@ class AboutWithStatements(Koan):
         except IOError:
             # should never happen
             self.fail()
-    
+
     def test_counting_lines(self):
         self.assertEqual(__, self.count_lines("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-        
+
     def find_line(self, file_name):
         try:
             f = open(file_name)
@@ -43,10 +43,10 @@ class AboutWithStatements(Koan):
         except IOError:
             # should never happen
             self.fail()
-    
+
     def test_finding_lines(self):
         self.assertEqual(__, self.find_line("example_file.txt"))
-    
+
     ## ------------------------------------------------------------------
     ## THINK ABOUT IT:
     ##
@@ -69,49 +69,49 @@ class AboutWithStatements(Koan):
     ## Python solves the problem using Context Managers. Consider the
     ## following code:
     ##
-    
+
     class FileContextManager():
         def __init__(self, file_name):
             self._file_name = file_name
             self._file = None
-        
+
         def __enter__(self):
             self._file = open(self._file_name)
             return self._file
-        
+
         def __exit__(self, cls, value, tb):
             self._file.close()
-    
+
     # Now we write:
-    
+
     def count_lines2(self, file_name):
         with self.FileContextManager(file_name) as f:
             count = 0
             for line in f.readlines():
                 count += 1
         return count
-    
+
     def test_counting_lines2(self):
         self.assertEqual(__, self.count_lines2("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-    
+
     def find_line2(self, file_name):
         # Rewrite find_line using the Context Manager.
         pass
-    
+
     def test_finding_lines2(self):
         self.assertEqual(__, self.find_line2("example_file.txt"))
         self.assertNotEqual(None, self.find_line2("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-    
+
     def count_lines3(self, file_name):
         with open(file_name) as f:
             count = 0
             for line in f.readlines():
                 count += 1
             return count
-    
+
     def test_open_already_has_its_own_built_in_context_manager(self):
         self.assertEqual(__, self.count_lines3("example_file.txt"))

--- a/python2/koans/another_local_module.py
+++ b/python2/koans/another_local_module.py
@@ -13,7 +13,7 @@ class Hamster(object):
     def name(self):
         return "Phil"
 
-    
+
 class _SecretSquirrel(object):
     @property
     def name(self):

--- a/python2/libs/colorama/ansitowin32.py
+++ b/python2/libs/colorama/ansitowin32.py
@@ -118,7 +118,7 @@ class AnsiToWin32(object):
             self.wrapped.flush()
         if self.autoreset:
             self.reset_all()
-        
+
 
     def reset_all(self):
         if self.convert:

--- a/python2/libs/mock.py
+++ b/python2/libs/mock.py
@@ -26,7 +26,7 @@ __version__ = '0.6.0 modified by Greg Malcolm'
 class SentinelObject(object):
     def __init__(self, name):
         self.name = name
-        
+
     def __repr__(self):
         return '<SentinelObject "{0!s}">'.format(self.name)
 
@@ -34,11 +34,11 @@ class SentinelObject(object):
 class Sentinel(object):
     def __init__(self):
         self._sentinels = {}
-        
+
     def __getattr__(self, name):
         return self._sentinels.setdefault(name, SentinelObject(name))
-    
-    
+
+
 sentinel = Sentinel()
 
 DEFAULT = sentinel.DEFAULT
@@ -58,21 +58,21 @@ def _copy(value):
 
 class Mock(object):
 
-    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT, 
+    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT,
                  name=None, parent=None, wraps=None):
         self._parent = parent
         self._name = name
         if spec is not None and not isinstance(spec, list):
             spec = [member for member in dir(spec) if not _is_magic(member)]
-        
+
         self._methods = spec
         self._children = {}
         self._return_value = return_value
         self.side_effect = side_effect
         self._wraps = wraps
-        
+
         self.reset_mock()
-        
+
 
     def reset_mock(self):
         self.called = False
@@ -84,16 +84,16 @@ class Mock(object):
             child.reset_mock()
         if isinstance(self._return_value, Mock):
             self._return_value.reset_mock()
-        
-    
+
+
     def __get_return_value(self):
         if self._return_value is DEFAULT:
             self._return_value = Mock()
         return self._return_value
-    
+
     def __set_return_value(self, value):
         self._return_value = value
-        
+
     return_value = property(__get_return_value, __set_return_value)
 
 
@@ -102,7 +102,7 @@ class Mock(object):
         self.call_count += 1
         self.call_args = (args, kwargs)
         self.call_args_list.append((args, kwargs))
-        
+
         parent = self._parent
         name = self._name
         while parent is not None:
@@ -111,44 +111,44 @@ class Mock(object):
                 break
             name = parent._name + '.' + name
             parent = parent._parent
-        
+
         ret_val = DEFAULT
         if self.side_effect is not None:
-            if (isinstance(self.side_effect, Exception) or 
+            if (isinstance(self.side_effect, Exception) or
                 isinstance(self.side_effect, (type, ClassType)) and
                 issubclass(self.side_effect, Exception)):
                 raise self.side_effect
-            
+
             ret_val = self.side_effect(*args, **kwargs)
             if ret_val is DEFAULT:
                 ret_val = self.return_value
-        
+
         if self._wraps is not None and self._return_value is DEFAULT:
             return self._wraps(*args, **kwargs)
         if ret_val is DEFAULT:
             ret_val = self.return_value
         return ret_val
-    
-    
+
+
     def __getattr__(self, name):
         if self._methods is not None:
             if name not in self._methods:
                 raise AttributeError("Mock object has no attribute '{0!s}'".format(name))
         elif _is_magic(name):
             raise AttributeError(name)
-        
+
         if name not in self._children:
             wraps = None
             if self._wraps is not None:
                 wraps = getattr(self._wraps, name)
             self._children[name] = Mock(parent=self, name=name, wraps=wraps)
-            
+
         return self._children[name]
-    
-    
+
+
     def assert_called_with(self, *args, **kwargs):
         assert self.call_args == (args, kwargs), 'Expected: {0!s}\nCalled with: {1!s}'.format((args, kwargs), self.call_args)
-        
+
 
 def _dot_lookup(thing, comp, import_path):
     try:
@@ -199,8 +199,8 @@ class _patch(object):
                     patching.__exit__()
 
         patched.patchings = [self]
-        patched.__name__ = func.__name__ 
-        patched.compat_co_firstlineno = getattr(func, "compat_co_firstlineno", 
+        patched.__name__ = func.__name__
+        patched.compat_co_firstlineno = getattr(func, "compat_co_firstlineno",
                                                 func.func_code.co_firstlineno)
         return patched
 
@@ -209,7 +209,7 @@ class _patch(object):
         target = self.target
         name = self.attribute
         create = self.create
-        
+
         original = DEFAULT
         if _has_local_attr(target, name):
             try:
@@ -221,7 +221,7 @@ class _patch(object):
             raise AttributeError("{0!s} does not have the attribute {1!r}".format(target, name))
         return original
 
-    
+
     def __enter__(self):
         new, spec, = self.new, self.spec
         original = self.get_original()
@@ -247,15 +247,15 @@ class _patch(object):
         else:
             delattr(self.target, self.attribute)
         del self.temp_original
-            
-                
+
+
 def patch_object(target, attribute, new=DEFAULT, spec=None, create=False):
     return _patch(target, attribute, new, spec, create)
 
 
 def patch(target, new=DEFAULT, spec=None, create=False):
     try:
-        target, attribute = target.rsplit('.', 1)    
+        target, attribute = target.rsplit('.', 1)
     except (TypeError, ValueError):
         raise TypeError("Need a valid target to patch. You supplied: {0!r}".format(target,))
     target = _importer(target)

--- a/python2/runner/runner_tests/test_helper.py
+++ b/python2/runner/runner_tests/test_helper.py
@@ -6,10 +6,10 @@ import unittest
 from runner import helper
 
 class TestHelper(unittest.TestCase):
-    
+
     def test_that_get_class_name_works_with_a_string_instance(self):
         self.assertEqual("str", helper.cls_name(str()))
-        
+
     def test_that_get_class_name_works_with_a_4(self):
         self.assertEquals("int", helper.cls_name(4))
 

--- a/python2/runner/runner_tests/test_mountain.py
+++ b/python2/runner/runner_tests/test_mountain.py
@@ -13,9 +13,9 @@ class TestMountain(unittest.TestCase):
         path_to_enlightenment.koans = Mock()
         self.mountain = Mountain()
         self.mountain.stream.writeln = Mock()
-        
+
     def test_it_gets_test_results(self):
         self.mountain.lesson.learn = Mock()
         self.mountain.walk_the_path()
         self.assertTrue(self.mountain.lesson.learn.called)
-        
+

--- a/python2/runner/runner_tests/test_sensei.py
+++ b/python2/runner/runner_tests/test_sensei.py
@@ -89,35 +89,35 @@ class TestSensei(unittest.TestCase):
         path_to_enlightenment.koans = Mock()
         self.tests = Mock()
         self.tests.countTestCases = Mock()
-        
+
     def test_that_it_delegates_testing_to_test_cases(self):
         MockableTestResult.startTest = Mock()
         self.sensei.startTest(Mock())
         self.assertTrue(MockableTestResult.startTest.called)
-        
+
     def test_that_user_is_notified_if_test_involves_a_different_test_class_to_last_time(self):
         MockableTestResult.startTest = Mock()
-        
+
         self.sensei.prevTestClassName == 'AboutLumberjacks'
         nextTest = AboutParrots()
-        
+
         self.sensei.startTest(nextTest)
         self.assertTrue(self.sensei.stream.writeln.called)
-        
+
     def test_that_user_is_not_notified_about_test_class_repeats(self):
         MockableTestResult.startTest = Mock()
-        
+
         self.sensei.prevTestClassName == 'AboutParrots'
         nextTest = AboutParrots()
-        
+
         self.sensei.startTest(nextTest)
         self.assertTrue(self.sensei.stream.writeln.called)
-    
+
     def test_that_cached_classname_updates_after_the_test(self):
         self.assertEqual(None, self.sensei.prevTestClassName)
         self.sensei.startTest(Mock())
         self.assertNotEqual(None, self.sensei.prevTestClassName)
-    
+
     def test_that_errors_are_diverted_to_the_failures_list(self):
         MockableTestResult.addFailure = Mock()
         self.sensei.addError(Mock(), Mock())
@@ -133,7 +133,7 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(self.sensei.passesCount.called)
-        
+
     def test_that_if_there_are_failures_and_the_prev_class_is_different_successes_are_not_allowed(self):
         self.sensei.failures = [(AboutLumberjacks(), Mock())]
         self.sensei.prevTestClassName = "AboutTheMinitry"
@@ -153,7 +153,7 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(MockableTestResult.addSuccess.called)
-            
+
     def test_that_it_increases_the_passes_on_every_success(self):
         pass_count = self.sensei.pass_count
         MockableTestResult.addSuccess = Mock()
@@ -164,15 +164,15 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(self.sensei.stream.writeln.called)
-                    
+
     def test_that_nothing_is_returned_as_a_first_result_if_there_are_no_failures(self):
         self.sensei.failures = []
         self.assertEqual(None, self.sensei.firstFailure())
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_failures(self):
         self.sensei.failures = []
         self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_relevent_failures(self):
         self.sensei.failures = [
             (AboutTheKnightsWhoSayNi(),"File 'about_the_knights_whn_say_ni.py', line 24"),
@@ -180,7 +180,7 @@ class TestSensei(unittest.TestCase):
             (AboutMessiahs(),"File 'about_messiahs.py', line 844")
         ]
         self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_3_shuffled_results(self):
         self.sensei.failures = [
             (AboutTennis(),"File 'about_tennis.py', line 299"),
@@ -191,26 +191,26 @@ class TestSensei(unittest.TestCase):
             (AboutMrGumby(),"File 'about_mr_gumby.py', line odd"),
             (AboutMessiahs(),"File 'about_messiahs.py', line 844")
         ]
-        
+
         expected = [
             (AboutTennis(),"File 'about_tennis.py', line 2"),
             (AboutTennis(),"File 'about_tennis.py', line 30"),
             (AboutTennis(),"File 'about_tennis.py', line 299")
         ]
-        
+
         results = self.sensei.sortFailures("AboutTennis")
         self.assertEqual(3, len(results))
         self.assertEqual(2, results[0][0])
         self.assertEqual(30, results[1][0])
         self.assertEqual(299, results[2][0])
-    
+
     def test_that_it_will_choose_not_find_anything_with_non_standard_error_trace_string(self):
         self.sensei.failures = [
             (AboutMrGumby(),"File 'about_mr_gumby.py', line MISSING"),
         ]
         self.assertEqual(None, self.sensei.sortFailures("AboutMrGumby"))
-    
-    
+
+
     def test_that_it_will_choose_correct_first_result_with_lines_9_and_27(self):
         self.sensei.failures = [
             (AboutTrebuchets(),"File 'about_trebuchets.py', line 27"),
@@ -218,7 +218,7 @@ class TestSensei(unittest.TestCase):
             (AboutTrebuchets(),"File 'about_trebuchets.py', line 73v")
         ]
         self.assertEqual("File 'about_trebuchets.py', line 9", self.sensei.firstFailure()[1])
-    
+
     def test_that_it_will_choose_correct_first_result_with_multiline_test_classes(self):
         self.sensei.failures = [
             (AboutGiantFeet(),"File 'about_giant_feet.py', line 999"),
@@ -227,7 +227,7 @@ class TestSensei(unittest.TestCase):
             (AboutFreemasons(),"File 'about_freemasons.py', line 11")
         ]
         self.assertEqual("File 'about_giant_feet.py', line 44", self.sensei.firstFailure()[1])
-            
+
     def test_that_end_report_displays_something(self):
         self.sensei.learn()
         self.assertTrue(self.sensei.stream.writeln.called)
@@ -239,7 +239,7 @@ class TestSensei(unittest.TestCase):
 
         self.sensei.learn()
         self.assertTrue(self.sensei.total_lessons.called)
-        self.assertTrue(self.sensei.total_koans.called)     
+        self.assertTrue(self.sensei.total_koans.called)
 
     def test_that_end_report_shows_the_failure_report(self):
         self.sensei.errorReport = Mock()
@@ -262,7 +262,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.firstFailure.return_value = None
         self.sensei.errorReport()
         self.assertFalse(self.sensei.stream.writeln.called)
-        
+
     def test_that_error_report_features_the_assertion_error(self):
         self.sensei.scrapeAssertionError = Mock()
         self.sensei.firstFailure = Mock()
@@ -279,19 +279,19 @@ class TestSensei(unittest.TestCase):
 
     def test_that_scraping_the_assertion_error_with_nothing_gives_you_a_blank_back(self):
         self.assertEqual("", self.sensei.scrapeAssertionError(None))
-        
+
     def test_that_scraping_the_assertion_error_with_messaged_assert(self):
         self.assertEqual("  AssertionError: Another fine mess you've got me into Stanley...",
             self.sensei.scrapeAssertionError(error_assertion_with_message))
-        
+
     def test_that_scraping_the_assertion_error_with_assert_equals(self):
         self.assertEqual("  AssertionError: 4 != 99",
             self.sensei.scrapeAssertionError(error_assertion_equals))
-        
+
     def test_that_scraping_the_assertion_error_with_assert_true(self):
         self.assertEqual("  AssertionError",
             self.sensei.scrapeAssertionError(error_assertion_true))
-        
+
     def test_that_scraping_the_assertion_error_with_syntax_error(self):
         self.assertEqual("  SyntaxError: invalid syntax",
             self.sensei.scrapeAssertionError(error_mess))
@@ -312,7 +312,7 @@ class TestSensei(unittest.TestCase):
 
     def test_that_scraping_a_non_existent_stack_dump_gives_you_nothing(self):
         self.assertEqual("", self.sensei.scrapeInterestingStackDump(None))
-        
+
     def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_messaged_assert(self):
         expected = """  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 43, in test_durability
     self.assertEqual("Steel","Lard", "Another fine mess you've got me into Stanley...")"""
@@ -336,27 +336,27 @@ class TestSensei(unittest.TestCase):
     self.assertTrue(eoe"Pen" > "Sword", "nhnth")"""
         self.assertEqual(expected,
             self.sensei.scrapeInterestingStackDump(error_mess))
-        
+
     def test_that_if_there_are_no_failures_say_the_final_zenlike_remark(self):
         self.sensei.failures = None
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Spanish Inquisition", words)
         self.assertTrue(m and m.group(0))
-        
+
     def test_that_if_there_are_0_successes_it_will_say_the_first_zen_of_python_koans(self):
         self.sensei.pass_count = 0
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
-        
+
     def test_that_if_there_is_1_successes_it_will_say_the_second_zen_of_python_koans(self):
         self.sensei.pass_count = 1
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Explicit is better than implicit", words)
         self.assertTrue(m and m.group(0))
 
@@ -364,7 +364,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 10
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Sparse is better than dense", words)
         self.assertTrue(m and m.group(0))
 
@@ -372,7 +372,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 36
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Namespaces are one honking great idea", words)
         self.assertTrue(m and m.group(0))
 
@@ -380,7 +380,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 37
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
@@ -399,7 +399,7 @@ class TestSensei(unittest.TestCase):
     def test_total_koans_return_43_if_there_are_43_test_cases(self):
         self.sensei.tests.countTestCases = Mock()
         self.sensei.tests.countTestCases.return_value = 43
-        
+
         self.assertEqual(43, self.sensei.total_koans())
 
     def test_filter_all_lessons_will_discover_test_classes_if_none_have_been_discovered_yet(self):

--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -18,7 +18,7 @@ class Sensei(MockableTestResult):
         unittest.TestResult.__init__(self)
         self.stream = stream
         self.prevTestClassName = None
-        self.tests = path_to_enlightenment.koans()        
+        self.tests = path_to_enlightenment.koans()
         self.pass_count = 0
         self.lesson_pass_count  = 0
         self.all_lessons = None
@@ -36,12 +36,12 @@ class Sensei(MockableTestResult):
                     self.lesson_pass_count += 1
 
     def addSuccess(self, test):
-        if self.passesCount():            
+        if self.passesCount():
             MockableTestResult.addSuccess(self, test)
             self.stream.writeln( \
                 "  {0}{1}{2} has expanded your awareness.{3}{4}" \
                 .format(Fore.GREEN, Style.BRIGHT, test._testMethodName, \
-                Fore.RESET, Style.NORMAL))      
+                Fore.RESET, Style.NORMAL))
             self.pass_count += 1
 
     def addError(self, test, err):
@@ -52,7 +52,7 @@ class Sensei(MockableTestResult):
     def passesCount(self):
         return not (self.failures and helper.cls_name(self.failures[0][0]) !=
                     self.prevTestClassName)
-        
+
     def addFailure(self, test, err):
         MockableTestResult.addFailure(self, test, err)
 
@@ -64,31 +64,31 @@ class Sensei(MockableTestResult):
                 if m:
                     tup = (int(m.group(0)), test, err)
                     table.append(tup)
-               
+
         if table:
             return sorted(table)
         else:
             return None
-         
+
     def firstFailure(self):
         if not self.failures: return None
-        
+
         table = self.sortFailures(helper.cls_name(self.failures[0][0]))
-            
+
         if table:
             return (table[0][1], table[0][2])
         else:
             return None
-    
+
     def learn(self):
         self.errorReport()
-    
+
         self.stream.writeln("")
         self.stream.writeln("")
         self.stream.writeln(self.report_progress())
         self.stream.writeln("")
         self.stream.writeln(self.say_something_zenlike())
-        
+
         if self.failures: sys.exit(-1)
         self.stream.writeln(
             "\n{0}**************************************************" \
@@ -97,13 +97,13 @@ class Sensei(MockableTestResult):
             .format(Fore.MAGENTA))
         self.stream.writeln(
             "\nIf you want more, take a look at about_extra_credit_task.py")
-        
+
     def errorReport(self):
         problem = self.firstFailure()
-        if not problem: return 
-        test, err = problem 
+        if not problem: return
+        test, err = problem
         self.stream.writeln("  {0}{1}{2} has damaged your "
-          "karma.".format(Fore.RED, Style.BRIGHT, test._testMethodName))        
+          "karma.".format(Fore.RED, Style.BRIGHT, test._testMethodName))
 
         self.stream.writeln("\n{0}{1}You have not yet reached enlightenment ..." \
             .format(Fore.RESET, Style.NORMAL))
@@ -124,7 +124,7 @@ class Sensei(MockableTestResult):
             m = re.search("^[^^ ].*$",line)
             if m and m.group(0):
                 count+=1
-            
+
             if count>1:
                 error_text += ("  " + line.strip()).rstrip() + '\n'
         return error_text.strip('\n')
@@ -134,9 +134,9 @@ class Sensei(MockableTestResult):
             return ""
 
         lines = err.splitlines()
-        
+
         sep = '@@@@@SEP@@@@@'
-        
+
         scrape = ""
         for line in lines:
             m = re.search("^  File .*$",line)
@@ -146,9 +146,9 @@ class Sensei(MockableTestResult):
             m = re.search("^    \w(\w)+.*$",line)
             if m and m.group(0):
                 scrape += sep + line
-            
+
         lines = scrape.splitlines()
-                        
+
         scrape = ""
         for line in lines:
             m = re.search("^.*[/\\\\]koans[/\\\\].*$",line)
@@ -179,7 +179,7 @@ class Sensei(MockableTestResult):
             turn = self.pass_count % 37
 
             zenness = "";
-            if turn == 0:            
+            if turn == 0:
                 zenness = "Beautiful is better than ugly."
             elif turn == 1 or turn == 2:
                 zenness = "Explicit is better than implicit."
@@ -222,14 +222,14 @@ class Sensei(MockableTestResult):
             elif turn == 33 or turn == 34:
                 zenness = "If the implementation is easy to explain, " \
                           "it may be a good idea."
-            else: 
+            else:
                 zenness = "Namespaces are one honking great idea -- " \
                           "let's do more of those!"
-            return "{0}{1}{2}{3}".format(Fore.CYAN, zenness, Fore.RESET, Style.NORMAL); 
+            return "{0}{1}{2}{3}".format(Fore.CYAN, zenness, Fore.RESET, Style.NORMAL);
         else:
             return "{0}Nobody ever expects the Spanish Inquisition." \
                 .format(Fore.CYAN)
-        
+
         # Hopefully this will never ever happen!
         return "The temple in collapsing! Run!!!"
 
@@ -249,5 +249,5 @@ class Sensei(MockableTestResult):
             self.all_lessons = filter(lambda filename:
                                       "about_extra_credit" not in filename,
                                       self.all_lessons)
-            
+
         return self.all_lessons

--- a/python3/_runner_tests.py
+++ b/python3/_runner_tests.py
@@ -17,4 +17,3 @@ def suite():
 
 if __name__ == '__main__':
     unittest.TextTestRunner(verbosity=2).run(suite())
-    

--- a/python3/contemplate_koans.py
+++ b/python3/contemplate_koans.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
             "running it with Python 2 or older!\n\n"
             "Did you accidentally use the wrong python script? \nTry:\n\n" +
             "    python3 contemplate_koans.py\n")
-    else:        
+    else:
         from runner.mountain import Mountain
 
         Mountain().walk_the_path(sys.argv)

--- a/python3/koans/about_asserts.py
+++ b/python3/koans/about_asserts.py
@@ -10,7 +10,7 @@ class AboutAsserts(Koan):
         We shall contemplate truth by testing reality, via asserts.
         """
         self.assertTrue(False) # This should be true
-    
+
     def test_assert_with_message(self):
         """
         Enlightenment may be more easily achieved with appropriate messages.
@@ -37,14 +37,14 @@ class AboutAsserts(Koan):
         """
         expected_value = __
         actual_value = 1 + 1
-        
+
         self.assertEqual(expected_value, actual_value)
-    
+
     def test_that_unittest_asserts_work_the_same_way_as_python_asserts(self):
         """
         Knowing how things really work is half the battle
         """
-        
+
         # This throws an AssertionError exception
         assert False
-        
+

--- a/python3/koans/about_class_attributes.py
+++ b/python3/koans/about_class_attributes.py
@@ -10,38 +10,38 @@ from runner.koan import *
 class AboutClassAttributes(Koan):
     class Dog:
         pass
-    
+
     def test_objects_are_objects(self):
         fido = self.Dog()
         self.assertEqual(__, isinstance(fido, object))
 
     def test_classes_are_types(self):
         self.assertEqual(__, self.Dog.__class__ == type)
-       
+
     def test_classes_are_objects_too(self):
         self.assertEqual(__, issubclass(self.Dog, object))
-    
+
     def test_objects_have_methods(self):
         fido = self.Dog()
         self.assertEqual(__, len(dir(fido)))
-    
+
     def test_classes_have_methods(self):
         self.assertEqual(__, len(dir(self.Dog)))
 
     def test_creating_objects_without_defining_a_class(self):
-        singularity = object()        
+        singularity = object()
         self.assertEqual(__, len(dir(singularity)))
 
     def test_defining_attributes_on_individual_objects(self):
         fido = self.Dog()
         fido.legs = 4
-        
+
         self.assertEqual(__, fido.legs)
-    
+
     def test_defining_functions_on_individual_objects(self):
         fido = self.Dog()
         fido.wag = lambda : 'fidos wag'
-        
+
         self.assertEqual(__, fido.wag())
 
     def test_other_objects_are_not_affected_by_these_singleton_functions(self):
@@ -49,13 +49,13 @@ class AboutClassAttributes(Koan):
         rover = self.Dog()
 
         def wag():
-            return 'fidos wag'        
+            return 'fidos wag'
         fido.wag = wag
-        
+
         with self.assertRaises(___): rover.wag()
-    
+
     # ------------------------------------------------------------------
-    
+
     class Dog2:
         def wag(self):
             return 'instance wag'
@@ -69,14 +69,14 @@ class AboutClassAttributes(Koan):
         @staticmethod
         def bark():
             return "staticmethod bark, arg: None"
-    
+
         @classmethod
         def growl(cls):
-            return "classmethod growl, arg: cls=" + cls.__name__  
-                    
+            return "classmethod growl, arg: cls=" + cls.__name__
+
     def test_since_classes_are_objects_you_can_define_singleton_methods_on_them_too(self):
         self.assertRegexpMatches(self.Dog2.growl(), __)
-    
+
     def test_classmethods_are_not_independent_of_instance_methods(self):
         fido = self.Dog2()
         self.assertRegexpMatches(fido.growl(), __)
@@ -88,9 +88,9 @@ class AboutClassAttributes(Koan):
     def test_staticmethods_also_overshadow_instance_methods(self):
         fido = self.Dog2()
         self.assertRegexpMatches(fido.bark(), __)
-    
+
     # ------------------------------------------------------------------
-    
+
     class Dog3:
         def __init__(self):
             self._name = None
@@ -100,37 +100,37 @@ class AboutClassAttributes(Koan):
 
         def set_name_from_instance(self, name):
             self._name = name
-            
-        @classmethod    
+
+        @classmethod
         def get_name(cls):
             return cls._name
 
-        @classmethod    
+        @classmethod
         def set_name(cls, name):
             cls._name = name
-        
+
         name = property(get_name, set_name)
         name_from_instance = property(get_name_from_instance, set_name_from_instance)
-        
+
     def test_classmethods_can_not_be_used_as_properties(self):
         fido = self.Dog3()
         with self.assertRaises(___): fido.name = "Fido"
- 
+
     def test_classes_and_instances_do_not_share_instance_attributes(self):
         fido = self.Dog3()
         fido.set_name_from_instance("Fido")
         fido.set_name("Rover")
         self.assertEqual(__, fido.get_name_from_instance())
         self.assertEqual(__, self.Dog3.get_name())
-   
+
     def test_classes_and_instances_do_share_class_attributes(self):
         fido = self.Dog3()
         fido.set_name("Fido")
         self.assertEqual(__, fido.get_name())
         self.assertEqual(__, self.Dog3.get_name())
-    
+
     # ------------------------------------------------------------------
-    
+
     class Dog4:
         def a_class_method(cls):
             return 'dogs class method'
@@ -140,15 +140,15 @@ class AboutClassAttributes(Koan):
 
         a_class_method = classmethod(a_class_method)
         a_static_method = staticmethod(a_static_method)
-    
+
     def test_you_can_define_class_methods_without_using_a_decorator(self):
         self.assertEqual(__, self.Dog4.a_class_method())
 
     def test_you_can_define_static_methods_without_using_a_decorator(self):
         self.assertEqual(__, self.Dog4.a_static_method())
-        
+
     # ------------------------------------------------------------------
-    
+
     def test_heres_an_easy_way_to_explicitly_call_class_methods_from_instance_methods(self):
         fido = self.Dog4()
         self.assertEqual(__, fido.__class__.a_class_method())

--- a/python3/koans/about_control_statements.py
+++ b/python3/koans/about_control_statements.py
@@ -17,7 +17,7 @@ class AboutControlStatements(Koan):
         if True:
             result = 'true value'
         self.assertEqual(__, result)
-                
+
     def test_while_statement(self):
         i = 1
         result = 1
@@ -25,7 +25,7 @@ class AboutControlStatements(Koan):
             result = result * i
             i += 1
         self.assertEqual(__, result)
-    
+
     def test_break_statement(self):
         i = 1
         result = 1
@@ -34,26 +34,26 @@ class AboutControlStatements(Koan):
             result = result * i
             i += 1
         self.assertEqual(__, result)
-    
+
     def test_continue_statement(self):
         i = 0
         result = []
         while i < 10:
             i += 1
             if (i % 2) == 0: continue
-            result.append(i) 
+            result.append(i)
         self.assertEqual(__, result)
-    
+
     def test_for_statement(self):
         phrase = ["fish", "and", "chips"]
         result = []
         for item in phrase:
             result.append(item.upper())
         self.assertEqual([__, __, __], result)
-        
+
     def test_for_statement_with_tuples(self):
         round_table = [
-            ("Lancelot", "Blue"),            
+            ("Lancelot", "Blue"),
             ("Galahad", "I don't know!"),
             ("Robin", "Blue! I mean Green!"),
             ("Arthur", "Is that an African Swallow or Amazonian Swallow?")
@@ -61,12 +61,11 @@ class AboutControlStatements(Koan):
         result = []
         for knight, answer in round_table:
             result.append("Contestant: '" + knight + "'   Answer: '" + answer + "'")
-        
+
         text = __
-        
+
         self.assertRegexpMatches(result[2], text)
-        
+
         self.assertNoRegexpMatches(result[0], text)
         self.assertNoRegexpMatches(result[1], text)
         self.assertNoRegexpMatches(result[3], text)
-        

--- a/python3/koans/about_decorating_with_classes.py
+++ b/python3/koans/about_decorating_with_classes.py
@@ -4,7 +4,7 @@
 from runner.koan import *
 
 import functools
-        
+
 class AboutDecoratingWithClasses(Koan):
     def maximum(self, a, b):
         if a>b:
@@ -18,17 +18,17 @@ class AboutDecoratingWithClasses(Koan):
         the partial.
         """
         max = functools.partial(self.maximum)
-                
+
         self.assertEqual(__, max(7,23))
         self.assertEqual(__, max(10,-10))
-        
+
     def test_partial_that_wrappers_first_arg(self):
         max0 = functools.partial(self.maximum, 0)
 
         self.assertEqual(__, max0(-4))
         self.assertEqual(__, max0(5))
 
-    def test_partial_that_wrappers_all_args(self):        
+    def test_partial_that_wrappers_all_args(self):
         always99 = functools.partial(self.maximum, 99, 20)
         always20 = functools.partial(self.maximum, 9, 20)
 
@@ -40,43 +40,43 @@ class AboutDecoratingWithClasses(Koan):
     class doubleit:
         def __init__(self, fn):
             self.fn = fn
-    
+
         def __call__(self, *args):
             return self.fn(*args) + ', ' + self.fn(*args)
-    
+
         def __get__(self, obj, cls=None):
             if not obj:
                 # Decorating an unbound function
                 return self
             else:
                 # Decorating a bound method
-                return functools.partial(self, obj)        
+                return functools.partial(self, obj)
 
     @doubleit
     def foo(self):
         return "foo"
-    
+
     @doubleit
     def parrot(self, text):
         return text.upper()
-                
+
     def test_decorator_with_no_arguments(self):
         # To clarify: the decorator above the function has no arguments, even
         # if the decorated function does
-                
+
         self.assertEqual(__, self.foo())
         self.assertEqual(__, self.parrot('pieces of eight'))
 
     # ------------------------------------------------------------------
 
     def sound_check(self):
-        #Note: no decorator        
+        #Note: no decorator
         return "Testing..."
 
     def test_what_a_decorator_is_doing_to_a_function(self):
         #wrap the function with the decorator
         self.sound_check = self.doubleit(self.sound_check)
-        
+
         self.assertEqual(__, self.sound_check())
 
     # ------------------------------------------------------------------
@@ -84,22 +84,22 @@ class AboutDecoratingWithClasses(Koan):
     class documenter:
         def __init__(self, *args):
             self.fn_doc = args[0]
-    
+
         def __call__(self, fn):
             def decorated_function(*args):
                 return fn(*args)
-                
+
             if fn.__doc__:
                 decorated_function.__doc__ = fn.__doc__ + ": " + self.fn_doc
             else:
                 decorated_function.__doc__ = self.fn_doc
             return decorated_function
-        
+
     @documenter("Increments a value by one. Kind of.")
     def count_badly(self, num):
         num += 1
         if num==3:
-            return 5 
+            return 5
         else:
             return num
     @documenter("Does nothing")
@@ -115,7 +115,7 @@ class AboutDecoratingWithClasses(Koan):
         self.assertEqual(__, self.idler.__doc__)
 
     # ------------------------------------------------------------------
-        
+
     @documenter("DOH!")
     @doubleit
     @doubleit
@@ -125,4 +125,4 @@ class AboutDecoratingWithClasses(Koan):
     def test_we_can_chain_decorators(self):
         self.assertEqual(__, self.homer())
         self.assertEqual(__, self.homer.__doc__)
-    
+

--- a/python3/koans/about_decorating_with_functions.py
+++ b/python3/koans/about_decorating_with_functions.py
@@ -3,31 +3,31 @@
 
 from runner.koan import *
 
-            
+
 class AboutDecoratingWithFunctions(Koan):
     def addcowbell(fn):
         fn.wow_factor = 'COWBELL BABY!'
         return fn
-            
+
     @addcowbell
     def mediocre_song(self):
         return "o/~ We all live in a broken submarine o/~"
-                
+
     def test_decorators_can_modify_a_function(self):
         self.assertRegexpMatches(self.mediocre_song(), __)
-        self.assertEqual(__, self.mediocre_song.wow_factor)    
-    
+        self.assertEqual(__, self.mediocre_song.wow_factor)
+
     # ------------------------------------------------------------------
 
     def xmltag(fn):
         def func(*args):
             return '<' + fn(*args) + '/>'
         return func
-            
+
     @xmltag
     def render_tag(self, name):
         return name
-    
+
     def test_decorators_can_change_a_function_output(self):
         self.assertEqual(__, self.render_tag('llama'))
 

--- a/python3/koans/about_deleting_objects.py
+++ b/python3/koans/about_deleting_objects.py
@@ -8,36 +8,36 @@ class AboutDeletingObjects(Koan):
         lottery_nums = [4, 8, 15, 16, 23, 42]
         del lottery_nums[1]
         del lottery_nums[2:4]
-        
+
         self.assertEqual(___, lottery_nums)
-        
+
     def test_del_can_remove_entire_lists(self):
         lottery_nums = [4, 8, 15, 16, 23, 42]
         del lottery_nums
 
         with self.assertRaises(___): win = lottery_nums
-        
+
     # ====================================================================
-        
+
     class ClosingSale:
         def __init__(self):
             self.hamsters = 7
             self.zebras = 84
-            
+
         def cameras(self):
             return 34
-        
+
         def toilet_brushes(self):
             return 48
-        
+
         def jellies(self):
             return 5
-        
+
     def test_del_can_remove_attributes(self):
         crazy_discounts = self.ClosingSale()
         del self.ClosingSale.toilet_brushes
         del crazy_discounts.hamsters
-        
+
         try:
             still_available = crazy_discounts.toilet_brushes()
         except AttributeError as e:
@@ -47,7 +47,7 @@ class AboutDeletingObjects(Koan):
             still_available = crazy_discounts.hamsters
         except AttributeError as e:
             err_msg2 = e.args[0]
-        
+
         self.assertRegexpMatches(err_msg1, __)
         self.assertRegexpMatches(err_msg2, __)
 
@@ -56,7 +56,7 @@ class AboutDeletingObjects(Koan):
     class ClintEastwood:
         def __init__(self):
             self._name = None
-            
+
         def get_name(self):
             try:
                 return self._name
@@ -65,13 +65,13 @@ class AboutDeletingObjects(Koan):
 
         def set_name(self, name):
             self._name = name
-            
+
         def del_name(self):
             del self._name
-            
+
         name = property(get_name, set_name, del_name, \
             "Mr Eastwood's current alias")
-            
+
     def test_del_works_with_properties(self):
         cowboy = self.ClintEastwood()
         cowboy.name = 'Senor Ninguno'
@@ -79,14 +79,14 @@ class AboutDeletingObjects(Koan):
 
         del cowboy.name
         self.assertEqual(__, cowboy.name)
-        
-        
-    # ====================================================================        
+
+
+    # ====================================================================
 
     class Prisoner:
         def __init__(self):
             self._name = None
-        
+
         @property
         def name(self):
             return self._name
@@ -94,11 +94,11 @@ class AboutDeletingObjects(Koan):
         @name.setter
         def name(self, name):
             self._name = name
-            
+
         @name.deleter
         def name(self):
             self._name = 'Number Six'
-                        
+
     def test_another_way_to_make_a_deletable_property(self):
         citizen = self.Prisoner()
         citizen.name = "Patrick"
@@ -108,12 +108,12 @@ class AboutDeletingObjects(Koan):
         self.assertEqual(__, citizen.name)
 
     # ====================================================================
-        
+
     class MoreOrganisedClosingSale(ClosingSale):
         def __init__(self):
             self.last_deletion = None
             super().__init__()
-        
+
         def __delattr__(self, attr_name):
             self.last_deletion = attr_name
 

--- a/python3/koans/about_dice_project.py
+++ b/python3/koans/about_dice_project.py
@@ -8,15 +8,15 @@ import random
 class DiceSet:
     def __init__(self):
         self._values = None
-    
-    @property    
+
+    @property
     def values(self):
         return self._values
-              
+
     def roll(self, n):
         # Needs implementing!
         # Tip: random.randint(min, max) can be used to generate random numbers
-        pass    
+        pass
 
 class AboutDiceProject(Koan):
     def test_can_create_a_dice_set(self):
@@ -25,43 +25,43 @@ class AboutDiceProject(Koan):
 
     def test_rolling_the_dice_returns_a_set_of_integers_between_1_and_6(self):
         dice = DiceSet()
-        
+
         dice.roll(5)
         self.assertTrue(isinstance(dice.values, list), "should be a list")
         self.assertEqual(5, len(dice.values))
         for value in dice.values:
             self.assertTrue(value >= 1 and value <= 6, "value " + str(value) + " must be between 1 and 6")
-        
+
     def test_dice_values_do_not_change_unless_explicitly_rolled(self):
         dice = DiceSet()
         dice.roll(5)
         first_time = dice.values
         second_time = dice.values
         self.assertEqual(first_time, second_time)
-        
+
     def test_dice_values_should_change_between_rolls(self):
         dice = DiceSet()
-        
+
         dice.roll(5)
         first_time = dice.values
-        
+
         dice.roll(5)
         second_time = dice.values
-        
+
         self.assertNotEqual(first_time, second_time, \
             "Two rolls should not be equal")
-        
+
         # THINK ABOUT IT:
         #
         # If the rolls are random, then it is possible (although not
         # likely) that two consecutive rolls are equal.  What would be a
         # better way to test this?
-        
+
     def test_you_can_roll_different_numbers_of_dice(self):
         dice = DiceSet()
-        
+
         dice.roll(3)
         self.assertEqual(3, len(dice.values))
-        
+
         dice.roll(1)
         self.assertEqual(1, len(dice.values))

--- a/python3/koans/about_dictionaries.py
+++ b/python3/koans/about_dictionaries.py
@@ -13,32 +13,32 @@ class AboutDictionaries(Koan):
         self.assertEqual(dict, type(empty_dict))
         self.assertDictEqual({}, empty_dict)
         self.assertEqual(__, len(empty_dict))
-        
+
     def test_dictionary_literals(self):
         empty_dict = {}
         self.assertEqual(dict, type(empty_dict))
         babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, len(babel_fish))
-        
+
     def test_accessing_dictionaries(self):
         babel_fish = { 'one': 'uno', 'two': 'dos' }
         self.assertEqual(__, babel_fish['one'])
         self.assertEqual(__, babel_fish['two'])
-        
+
     def test_changing_dictionaries(self):
         babel_fish = { 'one': 'uno', 'two': 'dos' }
         babel_fish['one'] = 'eins'
-        
+
         expected = { 'two': 'dos', 'one': __ }
         self.assertDictEqual(expected, babel_fish)
-        
+
     def test_dictionary_is_unordered(self):
         dict1 = { 'one': 'uno', 'two': 'dos' }
         dict2 = { 'two': 'dos', 'one': 'uno' }
-        
+
         self.assertEqual(__, dict1 == dict2)
-        
-       
+
+
     def test_dictionary_keys_and_values(self):
         babel_fish = {'one': 'uno', 'two': 'dos'}
         self.assertEqual(__, len(babel_fish.keys()))
@@ -50,7 +50,7 @@ class AboutDictionaries(Koan):
 
     def test_making_a_dictionary_from_a_sequence_of_keys(self):
         cards = {}.fromkeys(('red warrior', 'green elf', 'blue valkyrie', 'yellow dwarf', 'confused looking zebra'), 42)
-        
+
         self.assertEqual(__, len(cards))
         self.assertEqual(__, cards['green elf'])
         self.assertEqual(__, cards['yellow dwarf'])

--- a/python3/koans/about_exceptions.py
+++ b/python3/koans/about_exceptions.py
@@ -7,33 +7,33 @@ class AboutExceptions(Koan):
 
     class MySpecialError(RuntimeError):
         pass
-    
+
     def test_exceptions_inherit_from_exception(self):
         mro = self.MySpecialError.mro()
         self.assertEqual(__, mro[1].__name__)
         self.assertEqual(__, mro[2].__name__)
         self.assertEqual(__, mro[3].__name__)
         self.assertEqual(__, mro[4].__name__)
-    
+
     def test_try_clause(self):
         result = None
         try:
             self.fail("Oops")
         except Exception as ex:
             result = 'exception handled'
-            
+
             ex2 = ex
-        
+
         self.assertEqual(__, result)
-    
+
         self.assertEqual(__, isinstance(ex2, Exception))
         self.assertEqual(__, isinstance(ex2, RuntimeError))
-    
+
         self.assertTrue(issubclass(RuntimeError, Exception), \
             "RuntimeError is a subclass of Exception")
-        
+
         self.assertEqual(__, ex2.args[0])
-    
+
     def test_raising_a_specific_error(self):
         result = None
         try:
@@ -41,10 +41,10 @@ class AboutExceptions(Koan):
         except self.MySpecialError as ex:
             result = 'exception handled'
             msg = ex.args[0]
-    
+
         self.assertEqual(__, result)
         self.assertEqual(__, msg)
-    
+
     def test_else_clause(self):
         result = None
         try:
@@ -54,10 +54,10 @@ class AboutExceptions(Koan):
             pass
         else:
             result = 'no damage done'
-      
+
         self.assertEqual(__, result)
 
-    
+
     def test_finally_clause(self):
         result = None
         try:
@@ -67,5 +67,5 @@ class AboutExceptions(Koan):
             pass
         finally:
             result = 'always run'
-      
+
         self.assertEqual(__, result)

--- a/python3/koans/about_extra_credit.py
+++ b/python3/koans/about_extra_credit.py
@@ -17,4 +17,3 @@ class AboutExtraCredit(Koan):
     # test suite in runner/path_to_enlightenment.py
     def test_extra_credit_task(self):
         pass
- 

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -11,27 +11,27 @@
 from runner.koan import *
 
 class AboutGenerators(Koan):
-        
+
     def test_generating_values_on_the_fly(self):
         result = list()
         bacon_generator = (n + ' bacon' for n in ['crunchy','veggie','danish'])
-        
+
         for bacon in bacon_generator:
             result.append(bacon)
-        
+
         self.assertEqual(__, result)
-            
+
     def test_generators_are_different_to_list_comprehensions(self):
         num_list = [x*2 for x in range(1,3)]
         num_generator = (x*2 for x in range(1,3))
-        
+
         self.assertEqual(2, num_list[0])
-        
+
         # A generator has to be iterated through.
         with self.assertRaises(___): num = num_generator[0]
-        
+
         self.assertEqual(__, list(num_generator)[0])
-        
+
         # Both list comprehensions and generators can be iterated though. However, a generator
         # function is only called on the first iteration. The values are generated on the fly
         # instead of stored.
@@ -43,18 +43,18 @@ class AboutGenerators(Koan):
 
         attempt1 = list(dynamite)
         attempt2 = list(dynamite)
-        
+
         self.assertEqual(__, list(attempt1))
         self.assertEqual(__, list(attempt2))
-    
+
     # ------------------------------------------------------------------
-    
+
     def simple_generator_method(self):
         yield 'peanut'
         yield 'butter'
         yield 'and'
         yield 'jelly'
-        
+
     def test_generator_method_will_yield_values_during_iteration(self):
         result = list()
         for item in self.simple_generator_method():
@@ -66,7 +66,7 @@ class AboutGenerators(Koan):
         self.assertEqual(__, next(result))
         self.assertEqual(__, next(result))
         result.close()
-        
+
     # ------------------------------------------------------------------
 
     def square_me(self, seq):
@@ -91,11 +91,11 @@ class AboutGenerators(Koan):
         self.assertEqual(__, list(result))
 
     # ------------------------------------------------------------------
-        
+
     def generator_with_coroutine(self):
         result = yield
         yield result
-    
+
     def test_generators_can_take_coroutines(self):
         generator = self.generator_with_coroutine()
 
@@ -115,32 +115,32 @@ class AboutGenerators(Koan):
             generator.send(1+2)
         except TypeError as ex:
           ex2 = ex
-        
+
         self.assertRegexpMatches(ex2.args[0], __)
-                
+
     # ------------------------------------------------------------------
-    
+
     def yield_tester(self):
         value = yield
         if value:
             yield value
         else:
             yield 'no value'
-    
+
     def test_generators_can_see_if_they_have_been_called_with_a_value(self):
         generator = self.yield_tester()
         next(generator)
         self.assertEqual('with value', generator.send('with value'))
-                         
+
         generator2 = self.yield_tester()
         next(generator2)
         self.assertEqual(__, next(generator2))
 
     def test_send_none_is_equivalent_to_next(self):
         generator = self.yield_tester()
-        
+
         next(generator)
         # 'next(generator)' is exactly equivalent to 'generator.send(None)'
         self.assertEqual(__, generator.send(None))
 
- 
+

--- a/python3/koans/about_inheritance.py
+++ b/python3/koans/about_inheritance.py
@@ -5,85 +5,85 @@ from runner.koan import *
 
 class AboutInheritance(Koan):
     class Dog:
-        def __init__(self, name): 
+        def __init__(self, name):
             self._name = name
 
         @property
         def name(self):
             return self._name
-            
+
         def bark(self):
             return "WOOF"
-  
+
     class Chihuahua(Dog):
         def wag(self):
             return "happy"
-    
+
         def bark(self):
             return "yip"
-  
+
     def test_subclasses_have_the_parent_as_an_ancestor(self):
         self.assertEqual(__, issubclass(self.Chihuahua, self.Dog))
-  
+
     def test_this_all_classes_in_python_3_ultimately_inherit_from_object_class(self):
         self.assertEqual(__, issubclass(self.Chihuahua, object))
-        
+
         # Note: This isn't the case in Python 2. In that version you have
         # to inherit from a built in class or object explicitly
-                         
+
     def test_instances_inherit_behavior_from_parent_class(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.name)
-  
+
     def test_subclasses_add_new_behavior(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.wag())
-    
+
         fido = self.Dog("Fido")
         with self.assertRaises(___): fido.wag()
-  
+
     def test_subclasses_can_modify_existing_behavior(self):
         chico = self.Chihuahua("Chico")
         self.assertEqual(__, chico.bark())
-    
+
         fido = self.Dog("Fido")
         self.assertEqual(__, fido.bark())
-  
+
     # ------------------------------------------------------------------
-  
+
     class BullDog(Dog):
         def bark(self):
             return super().bark() + ", GRR"
             # Note, super() is much simpler to use in Python 3!
-  
+
     def test_subclasses_can_invoke_parent_behavior_via_super(self):
         ralph = self.BullDog("Ralph")
         self.assertEqual(__, ralph.bark())
-  
+
     # ------------------------------------------------------------------
-  
+
     class GreatDane(Dog):
         def growl(self):
             return super().bark() + ", GROWL"
-  
+
     def test_super_works_across_methods(self):
         george = self.GreatDane("George")
         self.assertEqual(__, george.growl())
 
     # ---------------------------------------------------------
-    
+
     class Pug(Dog):
-        def __init__(self, name): 
+        def __init__(self, name):
             pass
-        
+
     class Greyhound(Dog):
-        def __init__(self, name): 
+        def __init__(self, name):
             super().__init__(name)
 
     def test_base_init_does_not_get_called_automatically(self):
         snoopy = self.Pug("Snoopy")
         with self.assertRaises(___): name = snoopy.name
-        
+
     def test_base_init_has_to_be_called_explicitly(self):
         boxer = self.Greyhound("Boxer")
         self.assertEqual(__, boxer.name)

--- a/python3/koans/about_iteration.py
+++ b/python3/koans/about_iteration.py
@@ -7,12 +7,12 @@ class AboutIteration(Koan):
 
     def test_iterators_are_a_type(self):
         it = iter(range(1,6))
-        
+
         fib = 0
-        
+
         for num in it:
             fib += num
-            
+
         self.assertEqual(__ , fib)
 
     def test_iterating_with_next(self):
@@ -25,8 +25,8 @@ class AboutIteration(Koan):
             next(stages)
         except StopIteration as ex:
             err_msg = 'Ran out of iterations'
-            
-        self.assertRegexpMatches(err_msg, __)         
+
+        self.assertRegexpMatches(err_msg, __)
 
     # ------------------------------------------------------------------
 
@@ -36,38 +36,38 @@ class AboutIteration(Koan):
     def test_map_transforms_elements_of_a_list(self):
         seq = [1, 2, 3]
         mapped_seq = list()
-   
+
         mapping = map(self.add_ten, seq)
-        
+
         self.assertNotEqual(list, type(mapping).__name__)
         self.assertEqual(__, type(mapping).__name__)
         # In Python 3 built in iterator funcs return iteratable view objects
         # instead of lists
-   
+
         for item in mapping:
             mapped_seq.append(item)
-            
+
         self.assertEqual(__, mapped_seq)
-        
+
         # None, iterator methods actually return objects of iter type in
         # python 3. In python 2 map() would give you a list.
-        
+
     def test_filter_selects_certain_items_from_a_list(self):
         def is_even(item):
             return (item % 2) == 0
 
         seq = [1, 2, 3, 4, 5, 6]
         even_numbers = list()
-   
+
         for item in filter(is_even, seq):
             even_numbers.append(item)
-            
+
         self.assertEqual(__, even_numbers)
-    
+
     def test_just_return_first_item_found(self):
         def is_big_name(item):
             return len(item) > 4
-        
+
         names = ["Jim", "Bill", "Clarence", "Doug", "Eli"]
         name = None
 
@@ -78,7 +78,7 @@ class AboutIteration(Koan):
             msg = 'Ran out of big names'
 
         self.assertEqual(__, name)
-        
+
 
     # ------------------------------------------------------------------
 
@@ -87,42 +87,42 @@ class AboutIteration(Koan):
 
     def multiply(self,accum,item):
         return accum * item
-        
+
     def test_reduce_will_blow_your_mind(self):
         import functools
         # As of Python 3 reduce() has been demoted from a builtin function
         # to the functools module.
-        
+
         result = functools.reduce(self.add, [2, 3, 4])
         self.assertEqual(__, type(result).__name__)
         # Reduce() syntax is same as Python 2
-        
+
         self.assertEqual(__, result)
-    
-        result2 = functools.reduce(self.multiply, [2, 3, 4], 1) 
+
+        result2 = functools.reduce(self.multiply, [2, 3, 4], 1)
         self.assertEqual(__, result2)
-    
+
         # Extra Credit:
         # Describe in your own words what reduce does.
-    
+
     # ------------------------------------------------------------------
 
-    def test_creating_lists_with_list_comprehensions(self):        
+    def test_creating_lists_with_list_comprehensions(self):
         feast = ['lambs', 'sloths', 'orangutans', 'breakfast cereals', 'fruit bats']
-        
+
         comprehension = [delicacy.capitalize() for delicacy in feast]
-        
+
         self.assertEqual(__, comprehension[0])
         self.assertEqual(__, comprehension[2])
-        
+
     def test_use_pass_for_iterations_with_no_body(self):
         for num in range(1,5):
             pass
-                
+
         self.assertEqual(__, num)
 
     # ------------------------------------------------------------------
-        
+
     def test_all_iteration_methods_work_on_any_sequence_not_just_lists(self):
         # Ranges are an iteratable sequence
         result = map(self.add_ten, range(1,4))

--- a/python3/koans/about_lambdas.py
+++ b/python3/koans/about_lambdas.py
@@ -13,14 +13,14 @@ class AboutLambdas(Koan):
         self.assertEqual(__, add_one(10))
 
     # ------------------------------------------------------------------
-    
+
     def make_order(self, order):
         return lambda qty: str(qty) + " " + order + "s"
-            
+
     def test_accessing_lambda_via_assignment(self):
         sausages = self.make_order('sausage')
         eggs = self.make_order('egg')
-        
+
         self.assertEqual(__, sausages(3))
         self.assertEqual(__, eggs(2))
 

--- a/python3/koans/about_list_assignments.py
+++ b/python3/koans/about_list_assignments.py
@@ -11,7 +11,7 @@ class AboutListAssignments(Koan):
     def test_non_parallel_assignment(self):
         names = ["John", "Smith"]
         self.assertEqual(__, names)
-        
+
     def test_parallel_assignments(self):
         first_name, last_name = ["John", "Smith"]
         self.assertEqual(__, first_name)
@@ -22,12 +22,12 @@ class AboutListAssignments(Koan):
         self.assertEqual(__, title)
         self.assertEqual(__, first_names)
         self.assertEqual(__, last_name)
-                        
+
     def test_parallel_assignments_with_sublists(self):
         first_name, last_name = [["Willie", "Rae"], "Johnson"]
         self.assertEqual(__, first_name)
         self.assertEqual(__, last_name)
-                
+
     def test_swapping_with_parallel_assignment(self):
         first_name = "Roy"
         last_name = "Rob"

--- a/python3/koans/about_lists.py
+++ b/python3/koans/about_lists.py
@@ -16,27 +16,27 @@ class AboutLists(Koan):
     def test_list_literals(self):
         nums = list()
         self.assertEqual([], nums)
-        
+
         nums[0:] = [1]
         self.assertEqual([1], nums)
-        
+
         nums[1:] = [2]
         self.assertListEqual([1, __], nums)
-        
+
         nums.append(333)
         self.assertListEqual([1, 2, __], nums)
-    
+
     def test_accessing_list_elements(self):
         noms = ['peanut', 'butter', 'and', 'jelly']
-        
+
         self.assertEqual(__, noms[0])
         self.assertEqual(__, noms[3])
         self.assertEqual(__, noms[-1])
         self.assertEqual(__, noms[-3])
-    
+
     def test_slicing_lists(self):
         noms = ['peanut', 'butter', 'and', 'jelly']
-        
+
         self.assertEqual(__, noms[0:1])
         self.assertEqual(__, noms[0:2])
         self.assertEqual(__, noms[2:2])
@@ -50,7 +50,7 @@ class AboutLists(Koan):
 
         self.assertEqual(__, noms[2:])
         self.assertEqual(__, noms[:2])
-    
+
     def test_lists_and_ranges(self):
         self.assertEqual(range, type(range(5)))
         self.assertNotEqual([1, 2, 3, 4, 5], range(1,6))
@@ -67,44 +67,44 @@ class AboutLists(Koan):
         knight = ['you', 'shall', 'pass']
         knight.insert(2, 'not')
         self.assertEqual(__, knight)
-        
+
         knight.insert(0, 'Arthur')
-        self.assertEqual(__, knight)  
-            
+        self.assertEqual(__, knight)
+
     def test_popping_lists(self):
         stack = [10, 20, 30, 40]
         stack.append('last')
-        
+
         self.assertEqual(__, stack)
-        
+
         popped_value = stack.pop()
         self.assertEqual(__, popped_value)
         self.assertEqual(__, stack)
-        
+
         popped_value = stack.pop(1)
         self.assertEqual(__, popped_value)
         self.assertEqual(__, stack)
-        
+
         # Notice that there is a "pop" but no "push" in python?
-        
+
         # Part of the Python philosophy is that there ideally should be one and
         # only one way of doing anything. A 'push' is the same as an 'append'.
-        
+
         # To learn more about this try typing "import this" from the python
         # console... ;)
-        
+
     def test_making_queues(self):
         queue = [1, 2]
         queue.append('last')
-        
+
         self.assertEqual(__, queue)
-        
+
         popped_value = queue.pop(0)
         self.assertEqual(__, popped_value)
         self.assertEqual(__, queue)
-        
+
         # Note, for Python 2 popping from the left hand side of a list is
         # inefficient. Use collections.deque instead.
-        
+
         # This is not an issue for Python 3 though
-        
+

--- a/python3/koans/about_method_bindings.py
+++ b/python3/koans/about_method_bindings.py
@@ -11,10 +11,10 @@ def function2():
 
 class Class:
     def method(self):
-        return "parrot" 
+        return "parrot"
 
 class AboutMethodBindings(Koan):
-    def test_methods_are_bound_to_an_object(self):       
+    def test_methods_are_bound_to_an_object(self):
         obj = Class()
         self.assertEqual(__, obj.method.__self__ == obj)
 
@@ -22,12 +22,12 @@ class AboutMethodBindings(Koan):
         obj = Class()
         self.assertEqual(__, obj.method())
         self.assertEqual(__, obj.method.__func__(obj))
-        
+
     def test_functions_have_attributes(self):
         obj = Class()
         self.assertEqual(__, len(dir(function)))
         self.assertEqual(__, dir(function) == dir(obj.method.__func__))
-        
+
     def test_methods_have_different_attributes(self):
         obj = Class()
         self.assertEqual(__, len(dir(obj.method)))
@@ -38,13 +38,13 @@ class AboutMethodBindings(Koan):
 
     def test_setting_attributes_on_a_bound_method_directly(self):
         obj = Class()
-        with self.assertRaises(___): obj.method.cherries = 3 
- 
+        with self.assertRaises(___): obj.method.cherries = 3
+
     def test_setting_attributes_on_methods_by_accessing_the_inner_function(self):
         obj = Class()
         obj.method.__func__.cherries = 3
         self.assertEqual(__, obj.method.cherries)
-        
+
     def test_functions_can_have_inner_functions(self):
         function2.get_fruit = function
         self.assertEqual(__, function2.get_fruit())
@@ -60,7 +60,7 @@ class AboutMethodBindings(Koan):
             return (self, obj, cls)
 
     binding = BoundClass()
-            
+
     def test_get_descriptor_resolves_attribute_binding(self):
         bound_obj, binding_owner, owner_type = self.binding
         # Look at BoundClass.__get__():
@@ -82,9 +82,9 @@ class AboutMethodBindings(Koan):
             self.choice = val
 
     color = SuperColor()
-            
+
     def test_set_descriptor_changes_behavior_of_attribute_assignment_changes(self):
         self.assertEqual(None, self.color.choice)
         self.color = 'purple'
         self.assertEqual(__, self.color.choice)
-     
+

--- a/python3/koans/about_methods.py
+++ b/python3/koans/about_methods.py
@@ -13,7 +13,7 @@ def my_global_function(a,b):
 class AboutMethods(Koan):
     def test_calling_a_global_function(self):
         self.assertEqual(__, my_global_function(2,3))
-  
+
     # NOTE: Wrong number of arguments is not a SYNTAX error, but a
     # runtime error.
     def test_calling_functions_with_wrong_number_of_arguments(self):
@@ -25,17 +25,17 @@ class AboutMethods(Koan):
         self.assertRegexpMatches(msg,
             r'my_global_function\(\) takes exactly 2 ' +
             r'arguments \(0 given\)')
-        
+
         try:
             my_global_function(1, 2, 3)
         except Exception as e:
             msg = e.args[0]
-        
+
         # Note, watch out for parenthesis. They need slashes in front!
-        self.assertRegexpMatches(msg, __)        
-    
+        self.assertRegexpMatches(msg, __)
+
     # ------------------------------------------------------------------
-    
+
     def pointless_method(self, a, b):
         sum = a + b
 
@@ -43,7 +43,7 @@ class AboutMethods(Koan):
         self.assertEqual(__, self.pointless_method(1, 2))
         # Notice that methods accessed from class scope do not require
         # you to pass the first "self" argument?
-        
+
     # ------------------------------------------------------------------
 
     def method_with_defaults(self, a, b='default_value'):
@@ -67,13 +67,13 @@ class AboutMethods(Koan):
 
     def function_with_the_same_name(self, a, b):
         return a + b
-    
+
     def test_functions_without_self_arg_are_global_functions(self):
         def function_with_the_same_name(a, b):
             return a * b
 
         self.assertEqual(__, function_with_the_same_name(3,4))
-    
+
     def test_calling_methods_in_same_class_with_explicit_receiver(self):
         def function_with_the_same_name(a, b):
             return a * b
@@ -84,9 +84,9 @@ class AboutMethods(Koan):
 
     def another_method_with_the_same_name(self):
         return 10
-    
+
     link_to_overlapped_method = another_method_with_the_same_name
-    
+
     def another_method_with_the_same_name(self):
         return 42
 
@@ -114,7 +114,7 @@ class AboutMethods(Koan):
     # ------------------------------------------------------------------
 
     def one_line_method(self): return 'Madagascar'
-        
+
     def test_no_indentation_required_for_one_line_statement_bodies(self):
         self.assertEqual(__, self.one_line_method())
 
@@ -123,16 +123,16 @@ class AboutMethods(Koan):
     def method_with_documentation(self):
         "A string placed at the beginning of a function is used for documentation"
         return "ok"
-    
+
     def test_the_documentation_can_be_viewed_with_the_doc_method(self):
         self.assertRegexpMatches(self.method_with_documentation.__doc__, __)
 
     # ------------------------------------------------------------------
 
-    class Dog: 
+    class Dog:
         def name(self):
             return "Fido"
-        
+
         def _tail(self):
             # Prefixing a method with an underscore implies private scope
             return "wagging"
@@ -143,7 +143,7 @@ class AboutMethods(Koan):
     def test_calling_methods_in_other_objects(self):
         rover = self.Dog()
         self.assertEqual(__, rover.name())
-        
+
     def test_private_access_is_implied_but_not_enforced(self):
         rover = self.Dog()
 
@@ -152,11 +152,11 @@ class AboutMethods(Koan):
 
     def test_attributes_with_double_underscore_prefixes_are_subject_to_name_mangling(self):
         rover = self.Dog()
-        with self.assertRaises(___): password = rover.__password() 
-        
+        with self.assertRaises(___): password = rover.__password()
+
         # But this still is!
         self.assertEqual(__, rover._Dog__password())
-        
+
         # Name mangling exists to avoid name clash issues when subclassing.
         # It is not for providing effective access protection
 

--- a/python3/koans/about_modules.py
+++ b/python3/koans/about_modules.py
@@ -14,19 +14,19 @@ from .local_module_with_all_defined import *
 class AboutModules(Koan):
     def test_importing_other_python_scripts_as_modules(self):
         from . import local_module # local_module.py
-        
+
         duck = local_module.Duck()
         self.assertEqual(__, duck.name)
-        
+
     def test_importing_attributes_from_classes_using_from_keyword(self):
         from .local_module import Duck
-        
+
         duck = Duck() # no module qualifier needed this time
         self.assertEqual(__, duck.name)
 
     def test_we_can_import_multiple_items_at_once(self):
         from . import jims, joes
-        
+
         jims_dog = jims.Dog()
         joes_dog = joes.Dog()
         self.assertEqual(__, jims_dog.identify())
@@ -37,24 +37,24 @@ class AboutModules(Koan):
         #   from .other_local_module import *
         #
         # Import wildcard cannot be used from within classes or functions
-                                        
+
         goose = Goose()
         hamster = Hamster()
-        
+
         self.assertEqual(__, goose.name)
         self.assertEqual(__, hamster.name)
-        
+
     def test_modules_hide_attributes_prefixed_by_underscores(self):
         with self.assertRaises(___): private_squirrel = _SecretSquirrel()
 
     def test_private_attributes_are_still_accessible_in_modules(self):
         from .local_module import Duck # local_module.py
-        
+
         duck = Duck()
         self.assertEqual(__, duck._password)
         # module level attribute hiding doesn't affect class attributes
         # (unless the class itself is hidden).
-            
+
     def test_a_module_can_choose_which_attributes_are_available_to_wildcards(self):
         # NOTE Using this module level import declared at the top of this script:
         #   from .local_module_with_all_defined import *
@@ -66,6 +66,6 @@ class AboutModules(Koan):
         # How about velociraptors?
         lizard = _Velociraptor()
         self.assertEqual(__, lizard.name)
-        
+
         # SecretDuck? Never heard of her!
         with self.assertRaises(___): duck = SecretDuck()

--- a/python3/koans/about_monkey_patching.py
+++ b/python3/koans/about_monkey_patching.py
@@ -11,14 +11,14 @@ class AboutMonkeyPatching(Koan):
     class Dog:
         def bark(self):
             return "WOOF"
-    
+
     def test_as_defined_dogs_do_bark(self):
         fido = self.Dog()
         self.assertEqual(__, fido.bark())
 
     # ------------------------------------------------------------------
-    
-    # Add a new method to an existing class.      
+
+    # Add a new method to an existing class.
     def test_after_patching_dogs_can_both_wag_and_bark(self):
         def wag(self): return "HAPPY"
         self.Dog.wag = wag
@@ -26,25 +26,24 @@ class AboutMonkeyPatching(Koan):
         fido = self.Dog()
         self.assertEqual(__, fido.wag())
         self.assertEqual(__, fido.bark())
-    
+
     # ------------------------------------------------------------------
-    
+
     def test_most_built_in_classes_cannot_be_monkey_patched(self):
         try:
             int.is_even = lambda self: (self % 2) == 0
         except Exception as ex:
             err_msg = ex.args[0]
-            
+
         self.assertRegexpMatches(err_msg, __)
 
     # ------------------------------------------------------------------
 
     class MyInt(int): pass
-    
+
     def test_subclasses_of_built_in_classes_can_be_be_monkey_patched(self):
         self.MyInt.is_even = lambda self: (self % 2) == 0
-    
+
         self.assertEqual(__, self.MyInt(1).is_even())
         self.assertEqual(__, self.MyInt(2).is_even())
-            
- 
+

--- a/python3/koans/about_multiple_inheritance.py
+++ b/python3/koans/about_multiple_inheritance.py
@@ -14,20 +14,20 @@ class AboutMultipleInheritance(Koan):
 
         def set_name(self, new_name):
             self._name = new_name
-    
+
         def here(self):
             return "In Nameable class"
-       
-    class Animal:            
+
+    class Animal:
         def legs(self):
             return 4
 
         def can_climb_walls(self):
             return False
-        
+
         def here(self):
             return "In Animal class"
-                                            
+
     class Pig(Animal):
         def __init__(self):
             super().__init__()
@@ -36,13 +36,13 @@ class AboutMultipleInheritance(Koan):
         @property
         def name(self):
             return self._name
-           
+
         def speak(self):
             return "OINK"
-        
+
         def color(self):
-            return 'pink'        
-    
+            return 'pink'
+
         def here(self):
             return "In Pig class"
 
@@ -68,23 +68,23 @@ class AboutMultipleInheritance(Koan):
             super(AboutMultipleInheritance.Pig, self).__init__()
             super(AboutMultipleInheritance.Nameable, self).__init__()
             self._name = "Jeff"
-    
+
         def speak(self):
             return "This looks like a job for Spiderpig!"
-    
+
         def here(self):
             return "In Spiderpig class"
-        
-    # 
-    # Hierarchy:   
+
+    #
+    # Hierarchy:
     #               Animal
-    #              /     \  
-    #            Pig   Spider  Nameable 
+    #              /     \
+    #            Pig   Spider  Nameable
     #              \      |      /
     #                 Spiderpig
-    #    
+    #
     # ------------------------------------------------------------------
-  
+
     def test_normal_methods_are_available_in_the_object(self):
         jeff = self.Spiderpig()
         self.assertRegexpMatches(jeff.speak(), __)
@@ -96,14 +96,14 @@ class AboutMultipleInheritance(Koan):
         except:
             self.fail("This should not happen")
         self.assertEqual(__, jeff.can_climb_walls())
-  
+
     def test_base_class_methods_can_affect_instance_variables_in_the_object(self):
         jeff = self.Spiderpig()
         self.assertEqual(__, jeff.name)
-        
+
         jeff.set_name("Rover")
         self.assertEqual(__, jeff.name)
-  
+
     def test_left_hand_side_inheritance_tends_to_be_higher_priority(self):
         jeff = self.Spiderpig()
         self.assertEqual(__, jeff.color())
@@ -119,23 +119,23 @@ class AboutMultipleInheritance(Koan):
         mro = type(self.Spiderpig()).mro()
         self.assertEqual('Spiderpig', mro[0].__name__)
         self.assertEqual('Pig', mro[1].__name__)
-        self.assertEqual(__, mro[2].__name__) 
-        self.assertEqual(__, mro[3].__name__) 
-        self.assertEqual(__, mro[4].__name__) 
-        self.assertEqual(__, mro[5].__name__) 
+        self.assertEqual(__, mro[2].__name__)
+        self.assertEqual(__, mro[3].__name__)
+        self.assertEqual(__, mro[4].__name__)
+        self.assertEqual(__, mro[5].__name__)
 
     def test_confirm_the_mro_controls_the_calling_order(self):
         jeff = self.Spiderpig()
         self.assertRegexpMatches(jeff.here(), 'Spiderpig')
-        
-        next = super(AboutMultipleInheritance.Spiderpig, jeff)      
+
+        next = super(AboutMultipleInheritance.Spiderpig, jeff)
         self.assertRegexpMatches(next.here(), 'Pig')
 
         next = super(AboutMultipleInheritance.Pig, jeff)
         self.assertRegexpMatches(next.here(), __)
-        
+
         # Hang on a minute?!? That last class name might be a super class of
         # the 'jeff' object, but its hardly a superclass of Pig, is it?
         #
         # To avoid confusion it may help to think of super() as next_mro().
-        
+

--- a/python3/koans/about_none.py
+++ b/python3/koans/about_none.py
@@ -12,7 +12,7 @@ class AboutNone(Koan):
     def test_none_is_an_object(self):
         "Unlike NULL in a lot of languages"
         self.assertEqual(__, isinstance(None, object))
-   
+
     def test_none_is_universal(self):
         "There is only one None"
         self.assertEqual(____, None is None)
@@ -21,28 +21,28 @@ class AboutNone(Koan):
         """
         What is the Exception that is thrown when you call a method that does
         not exist?
-        
+
         Hint: launch python command console and try the code in the block below.
-        
+
         Don't worry about what 'try' and 'except' do, we'll talk about this later
         """
         try:
             None.some_method_none_does_not_know_about()
         except Exception as ex:
             ex2 = ex
-            
+
         # What exception has been caught?
         self.assertEqual(__, ex2.__class__.__name__)
-        
+
         # What message was attached to the exception?
         # (HINT: replace __ with part of the error message.)
         self.assertRegexpMatches(ex2.args[0], __)
-    
+
     def test_none_is_distinct(self):
         """
         None is distinct from other things which are False.
         """
         self.assertEqual(__, None is not 0)
         self.assertEqual(__, None is not False)
-    
-        
+
+

--- a/python3/koans/about_packages.py
+++ b/python3/koans/about_packages.py
@@ -18,7 +18,7 @@ from runner.koan import *
 #     about_attribute_access.py
 #     about_class_attributes.py
 #     about_classes.py
-#     ... 
+#     ...
 #     a_package_folder/
 #         __init__.py
 #         a_module.py
@@ -27,16 +27,16 @@ class AboutPackages(Koan):
     def test_subfolders_can_form_part_of_a_module_package(self):
         # Import ./a_package_folder/a_module.py
         from .a_package_folder.a_module import Duck
-        
+
         duck = Duck()
         self.assertEqual(__, duck.name)
-        
+
     def test_subfolders_become_modules_if_they_have_an_init_module(self):
         # Import ./a_package_folder/__init__.py
         from .a_package_folder import an_attribute
-        
+
         self.assertEqual(__, an_attribute)
-        
+
     def test_subfolders_without_an_init_module_are_not_part_of_the_package(self):
         # Import ./a_normal_folder/
         with self.assertRaises(___): from a_normal_folder import Duck
@@ -48,7 +48,7 @@ class AboutPackages(Koan):
         import contemplate_koans
 
         self.assertEqual(__, contemplate_koans.__name__)
-        
+
         # contemplate_koans.py is the root module in this package because its
         # the first python module called in koans.
         #

--- a/python3/koans/about_proxy_object_project.py
+++ b/python3/koans/about_proxy_object_project.py
@@ -21,11 +21,11 @@ from runner.koan import *
 class Proxy:
     def __init__(self, target_object):
         # WRITE CODE HERE
-        
+
         #initialize '_obj' attribute last. Trust me on this!
         self._obj = target_object
-    
-    # WRITE CODE HERE                                   
+
+    # WRITE CODE HERE
 
 # The proxy object should pass the following Koan:
 #
@@ -33,61 +33,61 @@ class AboutProxyObjectProject(Koan):
     def test_proxy_method_returns_wrapped_object(self):
         # NOTE: The Television class is defined below
         tv = Proxy(Television())
-        
+
         self.assertTrue(isinstance(tv, Proxy))
-    
+
     def test_tv_methods_still_perform_their_function(self):
         tv = Proxy(Television())
-        
+
         tv.channel = 10
         tv.power()
-        
+
         self.assertEqual(10, tv.channel)
         self.assertTrue(tv.is_on())
-    
+
     def test_proxy_records_messages_sent_to_tv(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.channel = 10
-        
+
         self.assertEqual(['power', 'channel'], tv.messages())
-    
+
     def test_proxy_handles_invalid_messages(self):
         tv = Proxy(Television())
-        
+
         ex = None
         with self.assertRaises(AttributeError):
             tv.no_such_method()
-        
-    
+
+
     def test_proxy_reports_methods_have_been_called(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.power()
-        
+
         self.assertTrue(tv.was_called('power'))
         self.assertFalse(tv.was_called('channel'))
-    
+
     def test_proxy_counts_method_calls(self):
         tv = Proxy(Television())
-        
+
         tv.power()
         tv.channel = 48
         tv.power()
-      
+
         self.assertEqual(2, tv.number_of_times_called('power'))
         self.assertEqual(1, tv.number_of_times_called('channel'))
         self.assertEqual(0, tv.number_of_times_called('is_on'))
-    
+
     def test_proxy_can_record_more_than_just_tv_objects(self):
         proxy = Proxy("Py Ohio 2010")
-      
+
         result = proxy.upper()
 
         self.assertEqual("PY OHIO 2010", result)
-        
+
         result = proxy.split()
 
         self.assertEqual(["Py", "Ohio", "2010"], result)
@@ -102,21 +102,21 @@ class Television:
     def __init__(self):
         self._channel = None
         self._power = None
-        
+
     @property
     def channel(self):
         return self._channel
 
     @channel.setter
     def channel(self, value):
-        self._channel = value        
-        
+        self._channel = value
+
     def power(self):
         if self._power == 'on':
             self._power = 'off'
         else:
             self._power = 'on'
-    
+
     def is_on(self):
         return self._power == 'on'
 
@@ -124,33 +124,33 @@ class Television:
 class TelevisionTest(Koan):
     def test_it_turns_on(self):
         tv = Television()
-        
+
         tv.power()
         self.assertTrue(tv.is_on())
-    
+
     def test_it_also_turns_off(self):
         tv = Television()
-        
+
         tv.power()
         tv.power()
-        
+
         self.assertFalse(tv.is_on())
-    
+
     def test_edge_case_on_off(self):
         tv = Television()
-        
+
         tv.power()
         tv.power()
         tv.power()
-            
+
         self.assertTrue(tv.is_on())
-        
+
         tv.power()
-        
+
         self.assertFalse(tv.is_on())
-  
+
     def test_can_set_the_channel(self):
         tv = Television()
-    
+
         tv.channel = 11
         self.assertEqual(11, tv.channel)

--- a/python3/koans/about_regex.py
+++ b/python3/koans/about_regex.py
@@ -29,7 +29,7 @@ class AboutRegex(Koan):
                 search()   -->  Scan through a string, looking for any location where this RE matches.
                 findall()  -->  Find all substrings where the RE matches, and returns them as a list.
                 finditer() -->  Find all substrings where the RE matches, and returns them as an iterator.
-                
+
         """
         string = "Hello, my name is Felix and this koans are based on the Ben's book: Regular Expressions in 10 minutes. Repeat My name is Felix"
         m = re.match('Felix', string) #TIP: Maybe match it's not the best option
@@ -49,7 +49,7 @@ class AboutRegex(Koan):
 
         self.assertEqual(re.findall("felix", string, 20), __)
         self.assertEqual(re.findall("felix", string, 10), __)
-                                              
+
     def test_matching_any_character(self):
         """
             Lesson 1 Matching any character
@@ -64,7 +64,7 @@ class AboutRegex(Koan):
                 + "sa1.xls"
 
         # TIP: remember the name of this lesson
-       
+
         change_this_search_string = 'a..xlx' # <-- I want to find all uses of myArray
         self.assertEquals(len(re.findall(change_this_search_string, string)),3)
 
@@ -83,7 +83,7 @@ class AboutRegex(Koan):
                 + "na1.xls\n"  \
                 + "na2.xls\n"  \
                 + "sa1.xls\n"  \
-                + "ca1.xls"  
+                + "ca1.xls"
         # I want to find all files for North America(na) or South America(sa), but not (ca)
         # TIP you can use the pattern .a. which matches in above test but in this case matches more than you want
         change_this_search_string = '[nsc]a[2-9].xls'
@@ -92,7 +92,7 @@ class AboutRegex(Koan):
     def test_anything_but_matching(self):
         """
             Lesson 2 Using character set ranges
-            Occsionally, you'll want a list of characters that you don't want to match. 
+            Occsionally, you'll want a list of characters that you don't want to match.
             Character sets can be negated using the ^ metacharacter.
 
         """
@@ -107,10 +107,10 @@ class AboutRegex(Koan):
                 + "na1.xls\n"  \
                 + "na2.xls\n"  \
                 + "sa1.xls\n"  \
-                + "ca1.xls"  
+                + "ca1.xls"
 
-        # I want to find the name sam 
+        # I want to find the name sam
         change_this_search_string = '[^nc]am'
-        self.assertEquals(re.findall(change_this_search_string, string), ['sam.xls'])        
+        self.assertEquals(re.findall(change_this_search_string, string), ['sam.xls'])
 
 

--- a/python3/koans/about_scope.py
+++ b/python3/koans/about_scope.py
@@ -3,7 +3,7 @@
 
 from runner.koan import *
 
-from . import jims 
+from . import jims
 from . import joes
 
 counter = 0 # Global
@@ -14,39 +14,39 @@ class AboutScope(Koan):
     #   Look in jims.py and joes.py to see definitions of Dog used
     #   for this set of tests
     #
-    
+
     def test_dog_is_not_available_in_the_current_scope(self):
         with self.assertRaises(___): fido = Dog()
-  
+
     def test_you_can_reference_nested_classes_using_the_scope_operator(self):
         fido = jims.Dog()
         # name 'jims' module name is taken from jim.py filename
-        
+
         rover = joes.Dog()
         self.assertEqual(__, fido.identify())
         self.assertEqual(__, rover.identify())
-        
+
         self.assertEqual(__, type(fido) == type(rover))
         self.assertEqual(__, jims.Dog == joes.Dog)
-  
+
     # ------------------------------------------------------------------
-  
+
     class str:
         pass
-    
+
     def test_bare_bones_class_names_do_not_assume_the_current_scope(self):
         self.assertEqual(__, AboutScope.str == str)
-    
+
     def test_nested_string_is_not_the_same_as_the_system_string(self):
         self.assertEqual(__, self.str == type("HI"))
-    
+
     def test_str_without_self_prefix_stays_in_the_global_scope(self):
         self.assertEqual(__, str == type("HI"))
 
     # ------------------------------------------------------------------
 
     PI = 3.1416
-  
+
     def test_constants_are_defined_with_an_initial_uppercase_letter(self):
         self.assertAlmostEqual(_____, self.PI)
         # Note, floating point numbers in python are not precise.
@@ -62,11 +62,11 @@ class AboutScope(Koan):
 
     def increment_using_local_counter(self, counter):
         counter = counter + 1
-       
+
     def increment_using_global_counter(self):
         global counter
-        counter = counter + 1       
-    
+        counter = counter + 1
+
     def test_incrementing_with_local_counter(self):
         global counter
         start = counter
@@ -87,25 +87,24 @@ class AboutScope(Koan):
             stuff = 'this is a local shop for local people'
             return stuff
         return from_the_league()
-    
+
     def nonlocal_access(self):
-        stuff = 'eels'               
+        stuff = 'eels'
         def from_the_boosh():
             nonlocal stuff
             return stuff
         return from_the_boosh()
-    
+
     def test_getting_something_locally(self):
         self.assertEqual(__, self.local_access())
-    
+
     def test_getting_something_nonlocally(self):
         self.assertEqual(__, self.nonlocal_access())
-    
+
     # ------------------------------------------------------------------
-    
+
     global deadly_bingo
     deadly_bingo = [4, 8, 15, 16, 23, 42]
-    
+
     def test_global_attributes_can_be_created_in_the_middle_of_a_class(self):
         self.assertEqual(__, deadly_bingo[5])
-    

--- a/python3/koans/about_scoring_project.py
+++ b/python3/koans/about_scoring_project.py
@@ -10,7 +10,7 @@ from runner.koan import *
 # A greed roll is scored as follows:
 #
 # * A set of three ones is 1000 points
-#   
+#
 # * A set of three numbers (other than ones) is worth 100 times the
 #   number. (e.g. three fives is 500 points).
 #
@@ -39,34 +39,34 @@ def score(dice):
 class AboutScoringProject(Koan):
     def test_score_of_an_empty_list_is_zero(self):
         self.assertEqual(0, score([]))
-    
+
     def test_score_of_a_single_roll_of_5_is_50(self):
         self.assertEqual(50, score([5]))
-    
+
     def test_score_of_a_single_roll_of_1_is_100(self):
         self.assertEqual(100, score([1]))
-    
+
     def test_score_of_multiple_1s_and_5s_is_the_sum_of_individual_scores(self):
         self.assertEqual(300, score([1,5,5,1]))
-    
+
     def test_score_of_single_2s_3s_4s_and_6s_are_zero(self):
         self.assertEqual(0, score([2,3,4,6]))
-    
+
     def test_score_of_a_triple_1_is_1000(self):
         self.assertEqual(1000, score([1,1,1]))
-    
+
     def test_score_of_other_triples_is_100x(self):
         self.assertEqual(200, score([2,2,2]))
         self.assertEqual(300, score([3,3,3]))
         self.assertEqual(400, score([4,4,4]))
         self.assertEqual(500, score([5,5,5]))
         self.assertEqual(600, score([6,6,6]))
-    
+
     def test_score_of_mixed_is_sum(self):
         self.assertEqual(250, score([2,5,2,2,3]))
         self.assertEqual(550, score([5,5,5,5]))
         self.assertEqual(1150, score([1,1,1,5,1]))
-        
+
     def test_ones_not_left_out(self):
         self.assertEqual(300, score([1,2,2,2]))
         self.assertEqual(350, score([1,5,2,2,2]))

--- a/python3/koans/about_strings.py
+++ b/python3/koans/about_strings.py
@@ -4,15 +4,15 @@
 from runner.koan import *
 
 class AboutStrings(Koan):
-    
+
     def test_double_quoted_strings_are_strings(self):
         string = "Hello, world."
         self.assertEqual(__, isinstance(string, str))
-    
+
     def test_single_quoted_strings_are_also_strings(self):
         string = 'Goodbye, world.'
         self.assertEqual(__, isinstance(string, str))
-    
+
     def test_triple_quote_strings_are_also_strings(self):
         string = """Howdy, world!"""
         self.assertEqual(__, isinstance(string, str))
@@ -28,11 +28,11 @@ class AboutStrings(Koan):
     def test_use_single_quotes_to_create_string_with_double_quotes(self):
         string = 'He said, "Go Away."'
         self.assertEqual(__, string)
-  
+
     def test_use_double_quotes_to_create_strings_with_single_quotes(self):
         string = "Don't"
         self.assertEqual(__, string)
-    
+
     def test_use_backslash_for_escaping_quotes_in_strings(self):
         a = "He said, \"Don't\""
         b = 'He said, "Don\'t"'
@@ -42,22 +42,22 @@ class AboutStrings(Koan):
         string = "It was the best of times,\n\
 It was the worst of times."
         self.assertEqual(__, len(string))
-        
+
     def test_triple_quoted_strings_can_span_lines(self):
         string = """
 Howdy,
 world!
 """
         self.assertEqual(__, len(string))
-    
+
     def test_triple_quoted_strings_need_less_escaping(self):
         a = "Hello \"world\"."
         b = """Hello "world"."""
         self.assertEqual(__, (a == b))
-    
+
     def but_you_still_have_to_be_careful_at_the_end_of_a_triple_quoted_string(self):
         string = """Hello "world\""""
-    
+
     def test_plus_concatenates_strings(self):
         string = "Hello, " + "world"
         self.assertEqual(__, string)
@@ -65,20 +65,20 @@ world!
     def test_adjacent_strings_are_concatenated_automatically(self):
         string = "Hello" ", " "world"
         self.assertEqual(__, string)
-        
+
     def test_plus_will_not_modify_original_strings(self):
         hi = "Hello, "
         there = "world"
         string = hi + there
         self.assertEqual(__, hi)
         self.assertEqual(__, there)
-    
+
     def test_plus_equals_will_append_to_end_of_string(self):
         hi = "Hello, "
         there = "world"
         hi += there
         self.assertEqual(__, hi)
-    
+
     def test_plus_equals_also_leaves_original_string_unmodified(self):
         original = "Hello, "
         hi = original
@@ -91,7 +91,7 @@ world!
         self.assertEqual('\n', string)
         self.assertEqual("""\n""", string)
         self.assertEqual(__, len(string))
-    
+
     def test_use_format_to_interpolate_variables(self):
         value1 = 'one'
         value2 = 2
@@ -103,42 +103,42 @@ world!
         value2 = 'DOH'
         string = "The values are {1}, {0}, {0} and {1}!".format(value1, value2)
         self.assertEqual(__, string)
-    
+
     def test_any_python_expression_may_be_interpolated(self):
         import math # import a standard python module with math functions
-        
+
         decimal_places = 4
         string = "The square root of 5 is {0:.{1}f}".format(math.sqrt(5), \
             decimal_places)
         self.assertEqual(__, string)
-    
+
     def test_you_can_get_a_substring_from_a_string(self):
         string = "Bacon, lettuce and tomato"
         self.assertEqual(__, string[7:10])
-    
+
     def test_you_can_get_a_single_character_from_a_string(self):
         string = "Bacon, lettuce and tomato"
         self.assertEqual(__, string[1])
-    
+
     def test_single_characters_can_be_represented_by_integers(self):
-        self.assertEqual(__, ord('a'))      
+        self.assertEqual(__, ord('a'))
         self.assertEqual(__, ord('b') == (ord('a') + 1))
-    
+
     def test_strings_can_be_split(self):
         string = "Sausage Egg Cheese"
         words = string.split()
         self.assertListEqual([__, __, __], words)
-    
+
     def test_strings_can_be_split_with_different_patterns(self):
         import re #import python regular expression library
-        
+
         string = "the,rain;in,spain"
         pattern = re.compile(',|;')
-        
+
         words = pattern.split(string)
-        
+
         self.assertListEqual([__, __, __, __], words)
-        
+
         # Pattern is a Python regular expression pattern which matches ',' or ';'
 
     def test_raw_strings_do_not_interpret_escape_characters(self):
@@ -147,8 +147,8 @@ world!
         self.assertEqual(__, string)
         self.assertEqual(__, len(string))
 
-        # Useful in regular expressions, file paths, URLs, etc.   
-      
+        # Useful in regular expressions, file paths, URLs, etc.
+
     def test_strings_can_be_joined(self):
         words = ["Now", "is", "the", "time"]
         self.assertEqual(__, ' '.join(words))

--- a/python3/koans/about_triangle_project.py
+++ b/python3/koans/about_triangle_project.py
@@ -10,13 +10,13 @@ class AboutTriangleProject(Koan):
     def test_equilateral_triangles_have_equal_sides(self):
         self.assertEqual('equilateral', triangle(2, 2, 2))
         self.assertEqual('equilateral', triangle(10, 10, 10))
-    
+
     def test_isosceles_triangles_have_exactly_two_sides_equal(self):
         self.assertEqual('isosceles', triangle(3, 4, 4))
         self.assertEqual('isosceles', triangle(4, 3, 4))
         self.assertEqual('isosceles', triangle(4, 4, 3))
         self.assertEqual('isosceles', triangle(10, 10, 2))
-    
+
     def test_scalene_triangles_have_no_equal_sides(self):
         self.assertEqual('scalene', triangle(3, 4, 5))
         self.assertEqual('scalene', triangle(10, 11, 12))

--- a/python3/koans/about_triangle_project2.py
+++ b/python3/koans/about_triangle_project2.py
@@ -16,10 +16,10 @@ class AboutTriangleProject2(Koan):
         with self.assertRaises(TriangleError):
             triangle(3, 4, -5)
 
-        with self.assertRaises(TriangleError):            
+        with self.assertRaises(TriangleError):
             triangle(1, 1, 3)
-            
+
         with self.assertRaises(TriangleError):
             triangle(2, 4, 2)
-            
+
 

--- a/python3/koans/about_true_and_false.py
+++ b/python3/koans/about_true_and_false.py
@@ -9,13 +9,13 @@ class AboutTrueAndFalse(Koan):
             return 'true stuff'
         else:
             return 'false stuff'
-        
+
     def test_true_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(True))
-        
+
     def test_false_is_treated_as_false(self):
         self.assertEqual(__, self.truth_value(False))
-        
+
     def test_none_is_treated_as_false(self):
         self.assertEqual(__, self.truth_value(None))
 
@@ -30,7 +30,7 @@ class AboutTrueAndFalse(Koan):
 
     def test_blank_strings_are_treated_as_false(self):
         self.assertEqual(__, self.truth_value(""))
-        
+
     def test_everything_else_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(1))
         self.assertEqual(__, self.truth_value(1,))

--- a/python3/koans/about_tuples.py
+++ b/python3/koans/about_tuples.py
@@ -7,46 +7,46 @@ class AboutTuples(Koan):
     def test_creating_a_tuple(self):
         count_of_three =  (1, 2, 5)
         self.assertEqual(5, __)
-        
+
     def test_tuples_are_immutable_so_item_assignment_is_not_possible(self):
         count_of_three =  (1, 2, 5)
         try:
             count_of_three[2] = "three"
         except TypeError as ex:
             msg = ex.args[0]
-            
+
         # Note, assertRegexpMatches() uses regular expression pattern matching,
-        # so you don't have to copy the whole message. 
+        # so you don't have to copy the whole message.
 
         self.assertRegexpMatches(msg, __)
-        
+
     def test_tuples_are_immutable_so_appending_is_not_possible(self):
         count_of_three =  (1, 2, 5)
         with self.assertRaises(___): count_of_three.append("boom")
-        
+
         # Tuples are less flexible than lists, but faster.
 
     def test_tuples_can_only_be_changed_through_replacement(self):
         count_of_three = (1, 2, 5)
-        
+
         list_count = list(count_of_three)
         list_count.append("boom")
         count_of_three = tuple(list_count)
-        
+
         self.assertEqual(__, count_of_three)
 
     def test_tuples_of_one_look_peculiar(self):
         self.assertEqual(__, (1).__class__.__name__)
         self.assertEqual(__, (1,).__class__.__name__)
         self.assertEqual(__, ("Hello comma!", ))
-        
+
     def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))
 
     def test_creating_empty_tuples(self):
         self.assertEqual(__ , ())
         self.assertEqual(__ , tuple()) #Sometimes less confusing
-        
+
     def test_tuples_can_be_embedded(self):
         lat = (37, 14, 6, 'N')
         lon = (115, 48, 40, 'W')
@@ -58,11 +58,11 @@ class AboutTuples(Koan):
             ("Illuminati HQ", (38, 52, 15.56, 'N'), (77, 3, 21.46, 'W')),
             ("Stargate B", (41, 10, 43.92, 'N'), (1, 49, 34.29, 'W')),
         ]
-        
+
         locations.append( ("Cthulu", (26, 40, 1, 'N'), (70, 45, 7, 'W')) )
-        
+
         self.assertEqual(__, locations[2][0])
         self.assertEqual(__, locations[0][1][2])
-        
-        
-        
+
+
+

--- a/python3/koans/about_with_statements.py
+++ b/python3/koans/about_with_statements.py
@@ -23,12 +23,12 @@ class AboutWithStatements(Koan):
         except IOError:
             # should never happen
             self.fail()
-    
+
     def test_counting_lines(self):
         self.assertEqual(__, self.count_lines("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-        
+
     def find_line(self, file_name):
         try:
             file = open(file_name)
@@ -42,10 +42,10 @@ class AboutWithStatements(Koan):
         except IOError:
             # should never happen
             self.fail()
-    
+
     def test_finding_lines(self):
         self.assertEqual(__, self.find_line("example_file.txt"))
-    
+
     ## ------------------------------------------------------------------
     ## THINK ABOUT IT:
     ##
@@ -68,49 +68,49 @@ class AboutWithStatements(Koan):
     ## Python solves the problem using Context Managers. Consider the
     ## following code:
     ##
-    
+
     class FileContextManager():
         def __init__(self, file_name):
             self._file_name = file_name
             self._file = None
-        
+
         def __enter__(self):
             self._file = open(self._file_name)
             return self._file
-        
+
         def __exit__(self, cls, value, tb):
             self._file.close()
-    
+
     # Now we write:
-    
+
     def count_lines2(self, file_name):
         with self.FileContextManager(file_name) as file:
             count = 0
             for line in file.readlines():
                 count += 1
         return count
-    
+
     def test_counting_lines2(self):
         self.assertEqual(__, self.count_lines2("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-    
+
     def find_line2(self, file_name):
-        # Rewrite find_line using the Context Manager.      
+        # Rewrite find_line using the Context Manager.
         pass
-    
+
     def test_finding_lines2(self):
         self.assertEqual(__, self.find_line2("example_file.txt"))
         self.assertNotEqual(__, self.find_line2("example_file.txt"))
-    
+
     # ------------------------------------------------------------------
-    
+
     def count_lines3(self, file_name):
         with open(file_name) as file:
             count = 0
             for line in file.readlines():
               count += 1
             return count
-    
+
     def test_open_already_has_its_own_built_in_context_manager(self):
         self.assertEqual(__, self.count_lines3("example_file.txt"))

--- a/python3/koans/another_local_module.py
+++ b/python3/koans/another_local_module.py
@@ -10,7 +10,7 @@ class Hamster:
     @property
     def name(self):
         return "Phil"
-    
+
 class _SecretSquirrel:
     @property
     def name(self):

--- a/python3/koans/local_module_with_all_defined.py
+++ b/python3/koans/local_module_with_all_defined.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 __all__ = (
-    'Goat', 
+    'Goat',
     '_Velociraptor'
 )
 

--- a/python3/libs/colorama/ansitowin32.py
+++ b/python3/libs/colorama/ansitowin32.py
@@ -118,7 +118,7 @@ class AnsiToWin32(object):
             self.wrapped.flush()
         if self.autoreset:
             self.reset_all()
-        
+
 
     def reset_all(self):
         if self.convert:

--- a/python3/libs/mock.py
+++ b/python3/libs/mock.py
@@ -26,7 +26,7 @@ __version__ = '0.6.0 modified by Greg Malcolm'
 class SentinelObject(object):
     def __init__(self, name):
         self.name = name
-        
+
     def __repr__(self):
         return '<SentinelObject "{0!s}">'.format(self.name)
 
@@ -34,11 +34,11 @@ class SentinelObject(object):
 class Sentinel(object):
     def __init__(self):
         self._sentinels = {}
-        
+
     def __getattr__(self, name):
         return self._sentinels.setdefault(name, SentinelObject(name))
-    
-    
+
+
 sentinel = Sentinel()
 
 DEFAULT = sentinel.DEFAULT
@@ -58,21 +58,21 @@ def _copy(value):
 
 class Mock(object):
 
-    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT, 
+    def __init__(self, spec=None, side_effect=None, return_value=DEFAULT,
                  name=None, parent=None, wraps=None):
         self._parent = parent
         self._name = name
         if spec is not None and not isinstance(spec, list):
             spec = [member for member in dir(spec) if not _is_magic(member)]
-        
+
         self._methods = spec
         self._children = {}
         self._return_value = return_value
         self.side_effect = side_effect
         self._wraps = wraps
-        
+
         self.reset_mock()
-        
+
 
     def reset_mock(self):
         self.called = False
@@ -84,16 +84,16 @@ class Mock(object):
             child.reset_mock()
         if isinstance(self._return_value, Mock):
             self._return_value.reset_mock()
-        
-    
+
+
     def __get_return_value(self):
         if self._return_value is DEFAULT:
             self._return_value = Mock()
         return self._return_value
-    
+
     def __set_return_value(self, value):
         self._return_value = value
-        
+
     return_value = property(__get_return_value, __set_return_value)
 
 
@@ -102,7 +102,7 @@ class Mock(object):
         self.call_count += 1
         self.call_args = (args, kwargs)
         self.call_args_list.append((args, kwargs))
-        
+
         parent = self._parent
         name = self._name
         while parent is not None:
@@ -111,44 +111,44 @@ class Mock(object):
                 break
             name = parent._name + '.' + name
             parent = parent._parent
-        
+
         ret_val = DEFAULT
         if self.side_effect is not None:
-            if (isinstance(self.side_effect, Exception) or 
+            if (isinstance(self.side_effect, Exception) or
                 isinstance(self.side_effect, (type, ClassType)) and
                 issubclass(self.side_effect, Exception)):
                 raise self.side_effect
-            
+
             ret_val = self.side_effect(*args, **kwargs)
             if ret_val is DEFAULT:
                 ret_val = self.return_value
-        
+
         if self._wraps is not None and self._return_value is DEFAULT:
             return self._wraps(*args, **kwargs)
         if ret_val is DEFAULT:
             ret_val = self.return_value
         return ret_val
-    
-    
+
+
     def __getattr__(self, name):
         if self._methods is not None:
             if name not in self._methods:
                 raise AttributeError("Mock object has no attribute '{0!s}'".format(name))
         elif _is_magic(name):
             raise AttributeError(name)
-        
+
         if name not in self._children:
             wraps = None
             if self._wraps is not None:
                 wraps = getattr(self._wraps, name)
             self._children[name] = Mock(parent=self, name=name, wraps=wraps)
-            
+
         return self._children[name]
-    
-    
+
+
     def assert_called_with(self, *args, **kwargs):
         assert self.call_args == (args, kwargs), 'Expected: {0!s}\nCalled with: {1!s}'.format((args, kwargs), self.call_args)
-        
+
 
 def _dot_lookup(thing, comp, import_path):
     try:
@@ -199,8 +199,8 @@ class _patch(object):
                     patching.__exit__()
 
         patched.patchings = [self]
-        patched.__name__ = func.__name__ 
-        patched.compat_co_firstlineno = getattr(func, "compat_co_firstlineno", 
+        patched.__name__ = func.__name__
+        patched.compat_co_firstlineno = getattr(func, "compat_co_firstlineno",
                                                 func.func_code.co_firstlineno)
         return patched
 
@@ -209,7 +209,7 @@ class _patch(object):
         target = self.target
         name = self.attribute
         create = self.create
-        
+
         original = DEFAULT
         if _has_local_attr(target, name):
             try:
@@ -221,7 +221,7 @@ class _patch(object):
             raise AttributeError("{0!s} does not have the attribute {1!r}".format(target, name))
         return original
 
-    
+
     def __enter__(self):
         new, spec, = self.new, self.spec
         original = self.get_original()
@@ -247,15 +247,15 @@ class _patch(object):
         else:
             delattr(self.target, self.attribute)
         del self.temp_original
-            
-                
+
+
 def patch_object(target, attribute, new=DEFAULT, spec=None, create=False):
     return _patch(target, attribute, new, spec, create)
 
 
 def patch(target, new=DEFAULT, spec=None, create=False):
     try:
-        target, attribute = target.rsplit('.', 1)    
+        target, attribute = target.rsplit('.', 1)
     except (TypeError, ValueError):
         raise TypeError("Need a valid target to patch. You supplied: {0!r}".format(target,))
     target = _importer(target)

--- a/python3/runner/mountain.py
+++ b/python3/runner/mountain.py
@@ -13,10 +13,10 @@ class Mountain:
         self.stream = WritelnDecorator(sys.stdout)
         self.tests = path_to_enlightenment.koans()
         self.lesson = Sensei(self.stream)
-    
+
     def walk_the_path(self, args=None):
         "Run the koans tests with a custom runner output."
-        
+
         if args and len(args) >=2:
             self.tests = unittest.TestLoader().loadTestsFromName("koans." + args[1])
 

--- a/python3/runner/runner_tests/test_helper.py
+++ b/python3/runner/runner_tests/test_helper.py
@@ -6,10 +6,10 @@ import unittest
 from runner import helper
 
 class TestHelper(unittest.TestCase):
-    
+
     def test_that_get_class_name_works_with_a_string_instance(self):
         self.assertEqual("str", helper.cls_name(str()))
-        
+
     def test_that_get_class_name_works_with_a_4(self):
         self.assertEquals("int", helper.cls_name(4))
 

--- a/python3/runner/runner_tests/test_mountain.py
+++ b/python3/runner/runner_tests/test_mountain.py
@@ -13,9 +13,9 @@ class TestMountain(unittest.TestCase):
         path_to_enlightenment.koans = Mock()
         self.mountain = Mountain()
         self.mountain.stream.writeln = Mock()
-        
+
     def test_it_gets_test_results(self):
         self.mountain.lesson.learn = Mock()
         self.mountain.walk_the_path()
         self.assertTrue(self.mountain.lesson.learn.called)
-        
+

--- a/python3/runner/runner_tests/test_sensei.py
+++ b/python3/runner/runner_tests/test_sensei.py
@@ -89,36 +89,36 @@ class TestSensei(unittest.TestCase):
         self.sensei.stream.writeln = Mock()
         path_to_enlightenment.koans = Mock()
         self.tests = Mock()
-        self.tests.countTestCases = Mock()        
-        
+        self.tests.countTestCases = Mock()
+
     def test_that_it_delegates_testing_to_test_cases(self):
         MockableTestResult.startTest = Mock()
         self.sensei.startTest(Mock())
         self.assertTrue(MockableTestResult.startTest.called)
-        
+
     def test_that_user_is_notified_if_test_involves_a_different_test_class_to_last_time(self):
         MockableTestResult.startTest = Mock()
-        
+
         self.sensei.prevTestClassName == 'AboutLumberjacks'
         nextTest = AboutParrots()
-        
+
         self.sensei.startTest(nextTest)
         self.assertTrue(self.sensei.stream.writeln.called)
-        
+
     def test_that_user_is_not_notified_about_test_class_repeats(self):
         MockableTestResult.startTest = Mock()
-        
+
         self.sensei.prevTestClassName == 'AboutParrots'
         nextTest = AboutParrots()
-        
+
         self.sensei.startTest(nextTest)
         self.assertTrue(self.sensei.stream.writeln.called)
-    
+
     def test_that_cached_classname_updates_after_the_test(self):
         self.assertEqual(None, self.sensei.prevTestClassName)
         self.sensei.startTest(Mock())
         self.assertNotEqual(None, self.sensei.prevTestClassName)
-    
+
     def test_that_errors_are_diverted_to_the_failures_list(self):
         MockableTestResult.addFailure = Mock()
         self.sensei.addError(Mock(), Mock())
@@ -134,7 +134,7 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(self.sensei.passesCount.called)
-        
+
     def test_that_if_there_are_failures_and_the_prev_class_is_different_successes_are_not_allowed(self):
         self.sensei.failures = [(AboutLumberjacks(), Mock())]
         self.sensei.prevTestClassName = "AboutTheMinitry"
@@ -154,7 +154,7 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(MockableTestResult.addSuccess.called)
-            
+
     def test_that_it_increases_the_passes_on_every_success(self):
         pass_count = self.sensei.pass_count
         MockableTestResult.addSuccess = Mock()
@@ -165,15 +165,15 @@ class TestSensei(unittest.TestCase):
         MockableTestResult.addSuccess = Mock()
         self.sensei.addSuccess(Mock())
         self.assertTrue(self.sensei.stream.writeln.called)
-                    
+
     def test_that_nothing_is_returned_as_a_first_result_if_there_are_no_failures(self):
         self.sensei.failures = []
         self.assertEqual(None, self.sensei.firstFailure())
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_failures(self):
         self.sensei.failures = []
         self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_relevent_failures(self):
         self.sensei.failures = [
             (AboutTheKnightsWhoSayNi(),"File 'about_the_knights_whn_say_ni.py', line 24"),
@@ -181,7 +181,7 @@ class TestSensei(unittest.TestCase):
             (AboutMessiahs(),"File 'about_messiahs.py', line 844")
         ]
         self.assertEqual(None, self.sensei.sortFailures("AboutLife"))
-    
+
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_3_shuffled_results(self):
         self.sensei.failures = [
             (AboutTennis(),"File 'about_tennis.py', line 299"),
@@ -192,26 +192,26 @@ class TestSensei(unittest.TestCase):
             (AboutMrGumby(),"File 'about_mr_gumby.py', line odd"),
             (AboutMessiahs(),"File 'about_messiahs.py', line 844")
         ]
-        
+
         expected = [
             (AboutTennis(),"File 'about_tennis.py', line 2"),
             (AboutTennis(),"File 'about_tennis.py', line 30"),
             (AboutTennis(),"File 'about_tennis.py', line 299")
         ]
-        
+
         results = self.sensei.sortFailures("AboutTennis")
         self.assertEqual(3, len(results))
         self.assertEqual(2, results[0][0])
         self.assertEqual(30, results[1][0])
         self.assertEqual(299, results[2][0])
-    
+
     def test_that_it_will_choose_not_find_anything_with_non_standard_error_trace_string(self):
         self.sensei.failures = [
             (AboutMrGumby(),"File 'about_mr_gumby.py', line MISSING"),
         ]
         self.assertEqual(None, self.sensei.sortFailures("AboutMrGumby"))
-    
-    
+
+
     def test_that_it_will_choose_correct_first_result_with_lines_9_and_27(self):
         self.sensei.failures = [
             (AboutTrebuchets(),"File 'about_trebuchets.py', line 27"),
@@ -219,7 +219,7 @@ class TestSensei(unittest.TestCase):
             (AboutTrebuchets(),"File 'about_trebuchets.py', line 73v")
         ]
         self.assertEqual("File 'about_trebuchets.py', line 9", self.sensei.firstFailure()[1])
-    
+
     def test_that_it_will_choose_correct_first_result_with_multiline_test_classes(self):
         self.sensei.failures = [
             (AboutGiantFeet(),"File 'about_giant_feet.py', line 999"),
@@ -228,7 +228,7 @@ class TestSensei(unittest.TestCase):
             (AboutFreemasons(),"File 'about_freemasons.py', line 11")
         ]
         self.assertEqual("File 'about_giant_feet.py', line 44", self.sensei.firstFailure()[1])
-            
+
     def test_that_end_report_displays_something(self):
         self.sensei.learn()
         self.assertTrue(self.sensei.stream.writeln.called)
@@ -240,7 +240,7 @@ class TestSensei(unittest.TestCase):
 
         self.sensei.learn()
         self.assertTrue(self.sensei.total_lessons.called)
-        self.assertTrue(self.sensei.total_koans.called)     
+        self.assertTrue(self.sensei.total_koans.called)
 
     def test_that_end_report_shows_the_failure_report(self):
         self.sensei.errorReport = Mock()
@@ -263,7 +263,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.firstFailure.return_value = None
         self.sensei.errorReport()
         self.assertFalse(self.sensei.stream.writeln.called)
-        
+
     def test_that_error_report_features_the_assertion_error(self):
         self.sensei.scrapeAssertionError = Mock()
         self.sensei.firstFailure = Mock()
@@ -280,19 +280,19 @@ class TestSensei(unittest.TestCase):
 
     def test_that_scraping_the_assertion_error_with_nothing_gives_you_a_blank_back(self):
         self.assertEqual("", self.sensei.scrapeAssertionError(None))
-        
+
     def test_that_scraping_the_assertion_error_with_messaged_assert(self):
         self.assertEqual("  AssertionError: Another fine mess you've got me into Stanley...",
             self.sensei.scrapeAssertionError(error_assertion_with_message))
-        
+
     def test_that_scraping_the_assertion_error_with_assert_equals(self):
         self.assertEqual("  AssertionError: 4 != 99",
             self.sensei.scrapeAssertionError(error_assertion_equals))
-        
+
     def test_that_scraping_the_assertion_error_with_assert_true(self):
         self.assertEqual("  AssertionError",
             self.sensei.scrapeAssertionError(error_assertion_true))
-        
+
     def test_that_scraping_the_assertion_error_with_syntax_error(self):
         self.assertEqual("  SyntaxError: invalid syntax",
             self.sensei.scrapeAssertionError(error_mess))
@@ -313,7 +313,7 @@ class TestSensei(unittest.TestCase):
 
     def test_that_scraping_a_non_existent_stack_dump_gives_you_nothing(self):
         self.assertEqual("", self.sensei.scrapeInterestingStackDump(None))
-        
+
     def test_that_scraping_the_stack_dump_only_shows_interesting_lines_for_messaged_assert(self):
         expected = """  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 43, in test_durability
     self.assertEqual("Steel","Lard", "Another fine mess you've got me into Stanley...")"""
@@ -341,23 +341,23 @@ class TestSensei(unittest.TestCase):
     def test_that_if_there_are_no_failures_say_the_final_zenlike_remark(self):
         self.sensei.failures = None
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Spanish Inquisition", words)
         self.assertTrue(m and m.group(0))
-        
+
     def test_that_if_there_are_0_successes_it_will_say_the_first_zen_of_python_koans(self):
         self.sensei.pass_count = 0
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
-        
+
     def test_that_if_there_is_1_successes_it_will_say_the_second_zen_of_python_koans(self):
         self.sensei.pass_count = 1
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Explicit is better than implicit", words)
         self.assertTrue(m and m.group(0))
 
@@ -365,7 +365,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 10
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Sparse is better than dense", words)
         self.assertTrue(m and m.group(0))
 
@@ -373,7 +373,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 36
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-                
+
         m = re.search("Namespaces are one honking great idea", words)
         self.assertTrue(m and m.group(0))
 
@@ -381,7 +381,7 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 37
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-        
+
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
@@ -400,10 +400,10 @@ class TestSensei(unittest.TestCase):
     def test_total_koans_return_43_if_there_are_43_test_cases(self):
         self.sensei.tests.countTestCases = Mock()
         self.sensei.tests.countTestCases.return_value = 43
-        
+
         self.assertEqual(43, self.sensei.total_koans())
 
     def test_filter_all_lessons_will_discover_test_classes_if_none_have_been_discovered_yet(self):
         self.sensei.all_lessons = 0
         self.assertTrue(len(self.sensei.filter_all_lessons()) > 10)
-        self.assertTrue(len(self.sensei.all_lessons) > 10)        
+        self.assertTrue(len(self.sensei.all_lessons) > 10)

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -17,7 +17,7 @@ class Sensei(MockableTestResult):
         unittest.TestResult.__init__(self)
         self.stream = stream
         self.prevTestClassName = None
-        self.tests = path_to_enlightenment.koans()        
+        self.tests = path_to_enlightenment.koans()
         self.pass_count = 0
         self.lesson_pass_count  = 0
         self.all_lessons = None
@@ -32,15 +32,15 @@ class Sensei(MockableTestResult):
                 self.stream.writeln("{0}{1}Thinking {2}".format(
                     Fore.RESET, Style.NORMAL, helper.cls_name(test)))
                 if helper.cls_name(test) != 'AboutAsserts':
-                    self.lesson_pass_count += 1                
+                    self.lesson_pass_count += 1
 
     def addSuccess(self, test):
-        if self.passesCount():            
+        if self.passesCount():
             MockableTestResult.addSuccess(self, test)
             self.stream.writeln( \
                 "  {0}{1}{2} has expanded your awareness.{3}{4}" \
                 .format(Fore.GREEN, Style.BRIGHT, test._testMethodName, \
-                Fore.RESET, Style.NORMAL))              
+                Fore.RESET, Style.NORMAL))
             self.pass_count += 1
 
     def addError(self, test, err):
@@ -50,7 +50,7 @@ class Sensei(MockableTestResult):
 
     def passesCount(self):
         return not (self.failures and helper.cls_name(self.failures[0][0]) != self.prevTestClassName)
-        
+
     def addFailure(self, test, err):
         MockableTestResult.addFailure(self, test, err)
 
@@ -62,31 +62,31 @@ class Sensei(MockableTestResult):
                 if m:
                     tup = (int(m.group(0)), test, err)
                     table.append(tup)
-               
+
         if table:
             return sorted(table)
         else:
             return None
-         
+
     def firstFailure(self):
         if not self.failures: return None
-        
+
         table = self.sortFailures(helper.cls_name(self.failures[0][0]))
-            
+
         if table:
             return (table[0][1], table[0][2])
         else:
             return None
-    
+
     def learn(self):
         self.errorReport()
-    
+
         self.stream.writeln("")
         self.stream.writeln("")
         self.stream.writeln(self.report_progress())
-        self.stream.writeln("")        
+        self.stream.writeln("")
         self.stream.writeln(self.say_something_zenlike())
-        
+
         if self.failures: return
         self.stream.writeln(
             "\n{0}**************************************************" \
@@ -95,14 +95,14 @@ class Sensei(MockableTestResult):
             .format(Fore.MAGENTA))
         self.stream.writeln(
             "\nIf you want more, take a look at about_extra_credit_task.py{0}{1}" \
-            .format(Fore.RESET, Style.NORMAL))           
-                    
+            .format(Fore.RESET, Style.NORMAL))
+
     def errorReport(self):
         problem = self.firstFailure()
-        if not problem: return 
-        test, err = problem 
+        if not problem: return
+        test, err = problem
         self.stream.writeln("  {0}{1}{2} has damaged your "
-          "karma.".format(Fore.RED, Style.BRIGHT, test._testMethodName))        
+          "karma.".format(Fore.RED, Style.BRIGHT, test._testMethodName))
 
         self.stream.writeln("\n{0}{1}You have not yet reached enlightenment ..." \
             .format(Fore.RESET, Style.NORMAL))
@@ -123,7 +123,7 @@ class Sensei(MockableTestResult):
             m = re.search("^[^^ ].*$",line)
             if m and m.group(0):
                 count+=1
-            
+
             if count>1:
                 error_text += ("  " + line.strip()).rstrip() + '\n'
         return error_text.strip('\n')
@@ -133,9 +133,9 @@ class Sensei(MockableTestResult):
             return ""
 
         lines = err.splitlines()
-        
+
         sep = '@@@@@SEP@@@@@'
-        
+
         scrape = ""
         for line in lines:
             m = re.search("^  File .*$",line)
@@ -145,9 +145,9 @@ class Sensei(MockableTestResult):
             m = re.search("^    \w(\w)+.*$",line)
             if m and m.group(0):
                 scrape += sep + line
-            
+
         lines = scrape.splitlines()
-                        
+
         scrape = ""
         for line in lines:
             m = re.search("^.*[/\\\\]koans[/\\\\].*$",line)
@@ -165,7 +165,7 @@ class Sensei(MockableTestResult):
                 "{1} lessons.\n".format(koans_complete, lessons_complete)
         sent2 = "You are now {0} koans and {1} lessons away from " \
                 "reaching enlightenment.".format(koans_remaining, lessons_remaining)
-        return sent1+sent2  
+        return sent1+sent2
 
     # Hat's tip to Tim Peters for the zen statements from The Zen
     # of Python (http://www.python.org/dev/peps/pep-0020/)
@@ -176,9 +176,9 @@ class Sensei(MockableTestResult):
     def say_something_zenlike(self):
         if self.failures:
             turn = self.pass_count % 37
-            
+
             zenness = "";
-            if turn == 0:            
+            if turn == 0:
                 zenness = "Beautiful is better than ugly."
             elif turn == 1 or turn == 2:
                 zenness = "Explicit is better than implicit."
@@ -221,14 +221,14 @@ class Sensei(MockableTestResult):
             elif turn == 33 or turn == 34:
                 zenness = "If the implementation is easy to explain, " \
                           "it may be a good idea."
-            else: 
+            else:
                 zenness = "Namespaces are one honking great idea -- " \
                           "let's do more of those!"
-            return "{0}{1}{2}{3}".format(Fore.CYAN, zenness, Fore.RESET, Style.NORMAL); 
+            return "{0}{1}{2}{3}".format(Fore.CYAN, zenness, Fore.RESET, Style.NORMAL);
         else:
             return "{0}Nobody ever expects the Spanish Inquisition." \
                 .format(Fore.CYAN)
-        
+
         # Hopefully this will never ever happen!
         return "The temple in collapsing! Run!!!"
 
@@ -249,4 +249,4 @@ class Sensei(MockableTestResult):
                                       "about_extra_credit" not in filename,
                                       self.all_lessons))
 
-        return self.all_lessons     
+        return self.all_lessons


### PR DESCRIPTION
Hi,

I think it's quite common to have Vim, your editor or your IDE automatically remove trailing white space upon saving a **.py** file. Every time I edit a file and look back to see what I've changed the diff contains many lines that I haven't even touched.

This pull request removes all trailing white space. So anybody else who has trailing spaces automatically removed won't have the same issue.

Cheers,
Matt
