### PR TITLE
Fixes the run.sh for Python2 in Arch Linux

### DIFF
--- a/python2/run.sh
+++ b/python2/run.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-python contemplate_koans.py
+if [ -x /usr/bin/python2 ]; then
+    python2 contemplate_koans.py
+else
+    python contemplate_koans.py
+fi


### PR DESCRIPTION
Arch linux defaults to Python 3, so `python2/run.sh` didn't work. This fixes it.
