### PR TITLE
Fixed typo in comment

### DIFF
--- a/python2/koans/about_scope.py
+++ b/python2/koans/about_scope.py
@@ -24,7 +24,7 @@ class AboutScope(Koan):
 
     def test_you_can_reference_nested_classes_using_the_scope_operator(self):
         fido = jims.Dog()
-        # name 'jims' module name is taken from jim.py filename
+        # name 'jims' module name is taken from jims.py filename
 
         rover = joes.Dog()
         self.assertEqual(__, fido.identify())

--- a/python3/koans/about_scope.py
+++ b/python3/koans/about_scope.py
@@ -20,7 +20,7 @@ class AboutScope(Koan):
 
     def test_you_can_reference_nested_classes_using_the_scope_operator(self):
         fido = jims.Dog()
-        # name 'jims' module name is taken from jim.py filename
+        # name 'jims' module name is taken from jims.py filename
 
         rover = joes.Dog()
         self.assertEqual(__, fido.identify())


### PR DESCRIPTION
The comment was explaining module naming so the typo could be confusing.
