### PR TITLE
Add a new test case about escaping double quotes in a triple quoted string.

### DIFF
--- a/python2/koans/about_strings.py
+++ b/python2/koans/about_strings.py
@@ -56,8 +56,9 @@ world!
         b = """Hello "world"."""
         self.assertEqual(__, (a == b))
 
-    def but_quotes_at_the_end_of_a_triple_quoted_string_are_still_tricky(self):
+    def test_escaping_quotes_at_the_end_of_triple_quoted_string(self):
         string = """Hello "world\""""
+        self.assertEqual(__, string)
 
     def test_plus_concatenates_strings(self):
         string = "Hello, " + "world"


### PR DESCRIPTION
This replaces a simple method in the test suite with a new test to test escaping quotes in a triple quoted string. I think this is a good case to learn more about when to escape double quotes in a triple quoted string.

The old function

```
def but_quotes_at_the_end_of_a_triple_quoted_string_are_still_tricky(self):
        string = """Hello "world\""""
```

This pull request is based on issue #61
Please close the issue once you accept the pull request. 

Thanks
Shishir Kakaraddi
