### PR TITLE
Fixed a bug with showing negative number of lessons to complete

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -174,7 +174,7 @@ class Sensei(MockableTestResult):
 
     def report_remaining(self):
         koans_remaining = self.total_koans() - self.pass_count
-        lessons_remaining = self.total_lessons() - self.pass_count
+        lessons_remaining = self.total_lessons() - self.lesson_pass_count
 
         return "You are now {0} koans and {1} lessons away from " \
             "reaching enlightenment.".format(

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -174,7 +174,7 @@ class Sensei(MockableTestResult):
 
     def report_remaining(self):
         koans_remaining = self.total_koans() - self.pass_count
-        lessons_remaining = self.total_lessons() - self.pass_count
+        lessons_remaining = self.total_lessons() - self.lesson_pass_count
 
         return "You are now {0} koans and {1} lessons away from " \
             "reaching enlightenment.".format(


### PR DESCRIPTION
A one line fix (in each of the versions - Python 2 & 3) where the wrong variable was referenced in the calculation of number of koans and number of lessons remaining.
