### PR TITLE
Typo in about_string_manipulation.py Python3

### DIFF
--- a/python3/koans/about_string_manipulation.py
+++ b/python3/koans/about_string_manipulation.py
@@ -11,7 +11,7 @@ class AboutStringManipulation(Koan):
         string = "The values are {0} and {1}".format(value1, value2)
         self.assertEqual(__, string)
 
-    def test_formatted_values_con_be_shown_in_any_order_or_be_repeated(self):
+    def test_formatted_values_can_be_shown_in_any_order_or_be_repeated(self):
         value1 = 'doh'
         value2 = 'DOH'
         string = "The values are {1}, {0}, {0} and {1}!".format(value1, value2)


### PR DESCRIPTION
While proceeding through the koans I noticed this.  Thought I might help fix it :).
