### PR TITLE
Removed unnecessary line continuation

### DIFF
--- a/python3/koans/about_string_manipulation.py
+++ b/python3/koans/about_string_manipulation.py
@@ -21,7 +21,7 @@ class AboutStringManipulation(Koan):
         import math # import a standard python module with math functions
 
         decimal_places = 4
-        string = "The square root of 5 is {0:.{1}f}".format(math.sqrt(5), \
+        string = "The square root of 5 is {0:.{1}f}".format(math.sqrt(5),
             decimal_places)
         self.assertEqual(__, string)
 


### PR DESCRIPTION
I'm not sure if you want commits that focus purely on style, nor whether you find extraneous line continuations of greater readability, but I figured I'd shoot you a patch in any case.  I've noticed some places where the code deviates in a minor fashion from http://www.python.org/dev/peps/pep-0008 as well (mainly in terms of comment placement / line length), would you like me to continue submitting this type of style-related patch or just ignore it?
