### PR TITLE
Makes regex example self explanatory.

### DIFF
--- a/python2/koans/about_regex.py
+++ b/python2/koans/about_regex.py
@@ -63,8 +63,8 @@ class AboutRegex(Koan):
         string = "Hello, my name is Felix or felix and this koan " + \
             "is based on Ben's book: Regular Expressions in 10 minutes."
 
-        self.assertEqual(re.findall("felix", string, 20), __)
-        self.assertEqual(re.findall("felix", string, 10), __)
+        self.assertEqual(re.findall("felix", string), __)
+        self.assertEqual(re.findall("felix", string, re.IGNORECASE), __)
 
     def test_matching_any_character(self):
         """


### PR DESCRIPTION
20 == `re.DOTALL | re.LOCALE` doesn't makes much sense here and can be confusing for a beginner.
also 10 == `re.IGNORECASE | re.MULTILINE` why overcomplicate it when the `string` doesn't even have a newline?
