### PR TITLE
add example with zero in a string to true_and_false koans

### DIFF
--- a/python2/koans/about_true_and_false.py
+++ b/python2/koans/about_true_and_false.py
@@ -39,3 +39,4 @@ class AboutTrueAndFalse(Koan):
             __,
             self.truth_value("Python is named after Monty Python"))
         self.assertEqual(__, self.truth_value(' '))
+        self.assertEqual(__, self.truth_value('0'))

--- a/python3/koans/about_true_and_false.py
+++ b/python3/koans/about_true_and_false.py
@@ -36,3 +36,4 @@ class AboutTrueAndFalse(Koan):
         self.assertEqual(__, self.truth_value(1,))
         self.assertEqual(__, self.truth_value("Python is named after Monty Python"))
         self.assertEqual(__, self.truth_value(' '))
+        self.assertEqual(__, self.truth_value('0'))


### PR DESCRIPTION
For those coming from PHP, this is a useful lesson. in PHP, '0' is false, while it is true in Python.
