### PR TITLE
Note on list.pop(0) in Python 2 vs Python 3 in about_lists

### DIFF
--- a/python3/koans/about_lists.py
+++ b/python3/koans/about_lists.py
@@ -103,8 +103,6 @@ class AboutLists(Koan):
         self.assertEqual(__, popped_value)
         self.assertEqual(__, queue)
 
-        # Note, for Python 2 popping from the left hand side of a list is
+        # Note, popping from the left hand side of a list is
         # inefficient. Use collections.deque instead.
-
-        # This is not an issue for Python 3 though
 


### PR DESCRIPTION
Hi Greg.

There's a note in about_lists saying that pop(0) performance in Py3 is non-issue compared to Py2.

I'm not entirely sure what that was supposed to mean, so I've looked for information on this note and haven't been able to find anything of the sort.

A brief test in Py3.4.1 also indicates that list.pop(0) vs deque.popleft() performance in Py3 is consistent with Py2.
That is, list.pop(0) is very slow and deque.popleft() isn't.

```
import timeit
timeit.timeit('''x = list(range(100000))
while x:
    x.pop(0)
 ''', number = 100)
```

385.9676046228002

```
timeit.timeit('''x = deque(range(1000000))
while x:
   x.popleft()
 ''', setup = 'from collections import deque', number = 100)
```

17.6067819813139
