### PR TITLE
Fix #98. Exclude extra credit from lesson_pass_count.

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -33,7 +33,7 @@ class Sensei(MockableTestResult):
                 self.stream.writeln()
                 self.stream.writeln("{0}{1}Thinking {2}".format(
                     Fore.RESET, Style.NORMAL, helper.cls_name(test)))
-                if helper.cls_name(test) != 'AboutAsserts':
+                if helper.cls_name(test) not in ['AboutAsserts', 'AboutExtraCredit']:
                     self.lesson_pass_count += 1
 
     def addSuccess(self, test):

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -33,7 +33,7 @@ class Sensei(MockableTestResult):
                 self.stream.writeln()
                 self.stream.writeln("{0}{1}Thinking {2}".format(
                     Fore.RESET, Style.NORMAL, helper.cls_name(test)))
-                if helper.cls_name(test) != 'AboutAsserts':
+                if helper.cls_name(test) not in ['AboutAsserts', 'AboutExtraCredit']:
                     self.lesson_pass_count += 1
 
     def addSuccess(self, test):


### PR DESCRIPTION
I encountered the same issue as @tombusby (#98), where the remaining lessons count goes below 0:

~~~
Thinking AboutRegex
  [...]
  test_matching_set_character has damaged your karma.

[...]

You have completed 312 koans and 39 lessons.
You are now 1 koans and -1 lessons away from reaching enlightenment.
~~~

This is because `total_lessons` filters "about_extra_credit" out of its count ([L264](https://github.com/gregmalcolm/python_koans/blob/master/python2/runner/sensei.py#L264), in `filter_all_lessons`), but `lesson_pass_count` does not — until now!

This issue was encountered and the patch tested against the python2 koans. I also made the change in the python3 version, but was not able to thoroughly test it there (I did not complete them yet).