### PR TITLE
Fix file name in final "If you want more" final message

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -99,7 +99,7 @@ class Sensei(MockableTestResult):
         self.stream.writeln("\n{0}That was the last one, well done!" \
             .format(Fore.MAGENTA))
         self.stream.writeln(
-            "\nIf you want more, take a look at about_extra_credit_task.py")
+            "\nIf you want more, take a look at about_extra_credit.py")
 
     def errorReport(self):
         problem = self.firstFailure()

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -98,7 +98,7 @@ class Sensei(MockableTestResult):
         self.stream.writeln("\n{0}That was the last one, well done!" \
             .format(Fore.MAGENTA))
         self.stream.writeln(
-            "\nIf you want more, take a look at about_extra_credit_task.py{0}{1}" \
+            "\nIf you want more, take a look at about_extra_credit.py{0}{1}" \
             .format(Fore.RESET, Style.NORMAL))
 
     def errorReport(self):


### PR DESCRIPTION
Another little PR, to fix the "extra credit" koan file name in the final "If you want more" message.

Before: 

> That was the last one, well done!
> 
> If you want more, take a look at **about_extra_credit_task.py**

After:

> That was the last one, well done!
> 
> If you want more, take a look at **about_extra_credit.py**