### PR TITLE
use "with" for file opening in about_iteration.py to allow for closing on exit without needing finally

### DIFF
--- a/python2/koans/about_iteration.py
+++ b/python2/koans/about_iteration.py
@@ -99,17 +99,11 @@ class AboutIteration(Koan):
         self.assertEqual(__, list(result))
 
         try:
-            f = open("example_file.txt")
-
-            try:
+            with open("example_file.txt") as f:
                 def make_upcase(line):
                     return line.strip().upper()
                 upcase_lines = map(make_upcase, f.readlines())
                 self.assertEqual(__, list(upcase_lines))
-            finally:
-                # Arg, this is ugly.
-                # We will figure out how to fix this later.
-                f.close()
         except IOError:
             # should never happen
             self.fail()

--- a/python3/koans/about_iteration.py
+++ b/python3/koans/about_iteration.py
@@ -121,17 +121,11 @@ class AboutIteration(Koan):
         self.assertEqual(__, list(result))
 
         try:
-            file = open("example_file.txt")
-
-            try:
+            with open("example_file.txt") as file:
                 def make_upcase(line):
                     return line.strip().upper()
                 upcase_lines = map(make_upcase, file.readlines())
                 self.assertEqual(__, list(upcase_lines))
-            finally:
-                # Arg, this is ugly.
-                # We will figure out how to fix this later.
-                file.close()
         except IOError:
             # should never happen
             self.fail()


### PR DESCRIPTION
The last koan in about_iteration.py has a comment that mentions wanting to fix a finally block that is used to close a file.

This pull request uses "with" when opening the file. Will using "with" be appropriate here? Is this a thing that should wait to be introduced? Will it do what you want?

According to the documentation for both python 2.7 and 3.4:

"It is good practice to use the with keyword when dealing with file objects. This has the advantage that the file is properly closed after its suite finishes, even if an exception is raised on the way. It is also much shorter than writing equivalent try-finally blocks."

See https://docs.python.org/2.7/tutorial/inputoutput.html and https://docs.python.org/3.4/tutorial/inputoutput.html