### PR TITLE
correct spelling of 'forth' to 'fourth' in about_comprehension.test_creating_a_dictionary_with_dictionary_comprehension.

### DIFF
--- a/python2/koans/about_comprehension.py
+++ b/python2/koans/about_comprehension.py
@@ -50,7 +50,7 @@ class AboutComprehension(Koan):
 
     def test_creating_a_dictionary_with_dictionary_comprehension(self):
         dict_of_weapons = {'first': 'fear', 'second': 'surprise',
-                           'third':'ruthless efficiency', 'forth':'fanatical devotion',
+                           'third':'ruthless efficiency', 'fourth':'fanatical devotion',
                            'fifth': None}
 
         dict_comprehension = { k.upper(): weapon for k, weapon in dict_of_weapons.iteritems() if weapon}

--- a/python3/koans/about_comprehension.py
+++ b/python3/koans/about_comprehension.py
@@ -50,7 +50,7 @@ class AboutComprehension(Koan):
 
     def test_creating_a_dictionary_with_dictionary_comprehension(self):
         dict_of_weapons = {'first': 'fear', 'second': 'surprise',
-                           'third':'ruthless efficiency', 'forth':'fanatical devotion',
+                           'third':'ruthless efficiency', 'fourth':'fanatical devotion',
                            'fifth': None}
 
         dict_comprehension = { k.upper(): weapon for k, weapon in dict_of_weapons.items() if weapon}


### PR DESCRIPTION
Corrected the spelling of the 4th key in the dict to be "fourth" instead of "forth"