### PR TITLE
Expanded differentiation between tuples and parentheses evaluation

### DIFF
--- a/python2/koans/about_tuples.py
+++ b/python2/koans/about_tuples.py
@@ -39,9 +39,8 @@ class AboutTuples(Koan):
         self.assertEqual(__, count_of_three)
 
     def test_tuples_of_one_look_peculiar(self):
-        self.assertEqual(__, (1).__class__)
-        self.assertEqual(__, (1,).__class__)
-        self.assertEqual(__, ("Hello comma!", ))
+        self.assertEqual(__, (2 * 3).__class__)
+        self.assertEqual(__, (2 * 3,).__class__)
 
     def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))

--- a/python3/koans/about_tuples.py
+++ b/python3/koans/about_tuples.py
@@ -36,9 +36,8 @@ class AboutTuples(Koan):
         self.assertEqual(__, count_of_three)
 
     def test_tuples_of_one_look_peculiar(self):
-        self.assertEqual(__, (1).__class__)
-        self.assertEqual(__, (1,).__class__)
-        self.assertEqual(__, ("Hello comma!", ))
+        self.assertEqual(__, (2 * 3).__class__)
+        self.assertEqual(__, (2 * 3,).__class__)
 
     def test_tuple_constructor_can_be_surprising(self):
         self.assertEqual(__, tuple("Surprise!"))


### PR DESCRIPTION
What threw me off is having an answer be exactly the same as the question, without needing to use my mental compiler. It wasn't until I read issue #12 and #57 when I realized that you were trying to show the difference between tuples and parentheses evaluation.  I didn't realize that `(1).__class__` was suppose to indicate parentheses evaluation so this pull request attempts to emphasize the difference. I feel the third example can be omitted as the two examples is sufficient.

This tries to keep consistency with pull request #6 and improves in a different manner than #34 