### PR TITLE
added sophisticated loop to run.sh

### DIFF
--- a/python2/run.sh
+++ b/python2/run.sh
@@ -1,7 +1,52 @@
 #!/bin/sh
 
 if [ -x /usr/bin/python2 ]; then
-    python2 -B contemplate_koans.py
+  BIN=python2
 else
-    python -B contemplate_koans.py
+  BIN=python
 fi
+
+function contemplate(){
+  $BIN -B contemplate_koans.py
+}
+
+if [ -z $2 ]; then
+  SLEEP_S=5
+else
+  SLEEP_S=$2
+fi
+
+while true; do
+  contemplate
+
+  case $1 in
+    help|h)
+      clear
+      echo "This script will contemplate the phython koans"
+      echo "usage: `basename $0` (mode)"
+      echo
+      echo "Optional modes:"
+      echo "\tkeeptesting (seconds)\t - Contemplate forever with a configurable delay"
+      echo "\tkeepasking \t\t - Asks you to contemplate over and over until you had enough"
+      echo
+      exit
+      ;;
+    keepasking)
+      if [ "$1" == "keepasking"  ]; then
+        read -p "Keep testing? [y/n] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]];then
+          break
+        fi
+      fi
+      ;;
+    keeptesting)
+      sleep $SLEEP_S
+      continue
+      ;;
+    *)
+      exit
+      ;;
+    esac
+done
+

--- a/python3/run.sh
+++ b/python3/run.sh
@@ -1,4 +1,46 @@
 #!/bin/sh
 
-python3 -B contemplate_koans.py
+function contemplate(){
+  python3 -B contemplate_koans.py
+}
+
+if [ -z $2 ]; then
+  SLEEP_S=5
+else
+  SLEEP_S=$2
+fi
+
+while true; do
+  contemplate
+
+  case $1 in
+    help|h)
+      clear
+      echo "This script will contemplate the phython koans"
+      echo "usage: `basename $0` (mode)"
+      echo
+      echo "Optional modes:"
+      echo "\tkeeptesting (seconds)\t - Contemplate forever with a configurable delay"
+      echo "\tkeepasking \t\t - Asks you to contemplate over and over until you had enough"
+      echo
+      exit
+      ;;
+    keepasking)
+      if [ "$1" == "keepasking"  ]; then
+        read -p "Keep testing? [y/n] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]];then
+          break
+        fi
+      fi
+      ;;
+    keeptesting)
+      sleep $SLEEP_S
+      continue
+      ;;
+    *)
+      exit
+      ;;
+    esac
+done
 


### PR DESCRIPTION
Having seen #111 I figured the unix/linux world should not be left outside ;)
Without any arguments the run.sh behaves as it used to but now also supports two custom modes
- keepasking which mimics the behaviour in #111
- keeptesting which simply loops the contemplation forever (with a customizable delay in seconds)