### PR TITLE
Updating Comments.

### DIFF
--- a/python2/koans/about_asserts.py
+++ b/python2/koans/about_asserts.py
@@ -15,13 +15,13 @@ class AboutAsserts(Koan):
         #
         #   http://bit.ly/about_asserts
 
-        self.assertTrue(False)  # This should be true
+        self.assertTrue(False)  # This should be True
 
     def test_assert_with_message(self):
         """
         Enlightenment may be more easily achieved with appropriate messages.
         """
-        self.assertTrue(False, "This should be true -- Please fix this")
+        self.assertTrue(False, "This should be True -- Please fix this")
 
     def test_fill_in_values(self):
         """

--- a/python3/koans/about_asserts.py
+++ b/python3/koans/about_asserts.py
@@ -14,13 +14,13 @@ class AboutAsserts(Koan):
         #
         #   http://bit.ly/about_asserts
 
-        self.assertTrue(False) # This should be true
+        self.assertTrue(False) # This should be True
 
     def test_assert_with_message(self):
         """
         Enlightenment may be more easily achieved with appropriate messages.
         """
-        self.assertTrue(False, "This should be true -- Please fix this")
+        self.assertTrue(False, "This should be True -- Please fix this")
 
     def test_fill_in_values(self):
         """


### PR DESCRIPTION
It should be True instead of true.

A user can write true by modifying the argument "False" in lines 17 and 23 in Python3 and lines 18 and 24 in Python2 files : "about_asserts.py". However that wont work , because the right keyword is "True". Hence the proposed change.