### PR TITLE
python3 has default regex asserts

### DIFF
--- a/python3/koans/about_attribute_access.py
+++ b/python3/koans/about_attribute_access.py
@@ -36,19 +36,19 @@ class AboutAttributeAccess(Koan):
     def test_all_attribute_reads_are_caught(self):
         catcher = self.CatchAllAttributeReads()
 
-        self.assertRegexpMatches(catcher.foobar, __)
+        self.assertRegex(catcher.foobar, __)
 
     def test_intercepting_return_values_can_disrupt_the_call_chain(self):
         catcher = self.CatchAllAttributeReads()
 
-        self.assertRegexpMatches(catcher.foobaz, __) # This is fine
+        self.assertRegex(catcher.foobaz, __) # This is fine
 
         try:
             catcher.foobaz(1)
         except TypeError as ex:
             err_msg = ex.args[0]
 
-        self.assertRegexpMatches(err_msg, __)
+        self.assertRegex(err_msg, __)
 
         # foobaz returns a string. What happens to the '(1)' part?
         # Try entering this into a python console to reproduce the issue:
@@ -59,7 +59,7 @@ class AboutAttributeAccess(Koan):
     def test_changes_to_the_getattribute_implementation_affects_getattr_function(self):
         catcher = self.CatchAllAttributeReads()
 
-        self.assertRegexpMatches(getattr(catcher, 'any_attribute'), __)
+        self.assertRegex(getattr(catcher, 'any_attribute'), __)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_class_attributes.py
+++ b/python3/koans/about_class_attributes.py
@@ -75,19 +75,19 @@ class AboutClassAttributes(Koan):
             return "classmethod growl, arg: cls=" + cls.__name__
 
     def test_since_classes_are_objects_you_can_define_singleton_methods_on_them_too(self):
-        self.assertRegexpMatches(self.Dog2.growl(), __)
+        self.assertRegex(self.Dog2.growl(), __)
 
     def test_classmethods_are_not_independent_of_instance_methods(self):
         fido = self.Dog2()
-        self.assertRegexpMatches(fido.growl(), __)
-        self.assertRegexpMatches(self.Dog2.growl(), __)
+        self.assertRegex(fido.growl(), __)
+        self.assertRegex(self.Dog2.growl(), __)
 
     def test_staticmethods_are_unbound_functions_housed_in_a_class(self):
-        self.assertRegexpMatches(self.Dog2.bark(), __)
+        self.assertRegex(self.Dog2.bark(), __)
 
     def test_staticmethods_also_overshadow_instance_methods(self):
         fido = self.Dog2()
-        self.assertRegexpMatches(fido.bark(), __)
+        self.assertRegex(fido.bark(), __)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_classes.py
+++ b/python3/koans/about_classes.py
@@ -15,7 +15,7 @@ class AboutClasses(Koan):
         self.assertEqual(__, fido.__class__.__name__)
 
     def test_classes_have_docstrings(self):
-        self.assertRegexpMatches(self.Dog.__doc__, __)
+        self.assertRegex(self.Dog.__doc__, __)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_control_statements.py
+++ b/python3/koans/about_control_statements.py
@@ -17,11 +17,11 @@ class AboutControlStatements(Koan):
         if True:
             result = 'true value'
         self.assertEqual(__, result)
-        
+
     def test_if_then_elif_else_statements(self):
         if False:
             result = 'first value'
-        elif True: 
+        elif True:
             result = 'true value'
         else:
             result = 'default value'
@@ -73,8 +73,8 @@ class AboutControlStatements(Koan):
 
         text = __
 
-        self.assertRegexpMatches(result[2], text)
+        self.assertRegex(result[2], text)
 
-        self.assertNoRegexpMatches(result[0], text)
-        self.assertNoRegexpMatches(result[1], text)
-        self.assertNoRegexpMatches(result[3], text)
+        self.assertNotRegex(result[0], text)
+        self.assertNotRegex(result[1], text)
+        self.assertNotRegex(result[3], text)

--- a/python3/koans/about_decorating_with_functions.py
+++ b/python3/koans/about_decorating_with_functions.py
@@ -14,7 +14,7 @@ class AboutDecoratingWithFunctions(Koan):
         return "o/~ We all live in a broken submarine o/~"
 
     def test_decorators_can_modify_a_function(self):
-        self.assertRegexpMatches(self.mediocre_song(), __)
+        self.assertRegex(self.mediocre_song(), __)
         self.assertEqual(__, self.mediocre_song.wow_factor)
 
     # ------------------------------------------------------------------
@@ -30,4 +30,3 @@ class AboutDecoratingWithFunctions(Koan):
 
     def test_decorators_can_change_a_function_output(self):
         self.assertEqual(__, self.render_tag('llama'))
-

--- a/python3/koans/about_deleting_objects.py
+++ b/python3/koans/about_deleting_objects.py
@@ -48,8 +48,8 @@ class AboutDeletingObjects(Koan):
         except AttributeError as e:
             err_msg2 = e.args[0]
 
-        self.assertRegexpMatches(err_msg1, __)
-        self.assertRegexpMatches(err_msg2, __)
+        self.assertRegex(err_msg1, __)
+        self.assertRegex(err_msg2, __)
 
     # ====================================================================
 

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -116,7 +116,7 @@ class AboutGenerators(Koan):
         except TypeError as ex:
           ex2 = ex
 
-        self.assertRegexpMatches(ex2.args[0], __)
+        self.assertRegex(ex2.args[0], __)
 
     # ------------------------------------------------------------------
 
@@ -142,5 +142,3 @@ class AboutGenerators(Koan):
         next(generator)
         # 'next(generator)' is exactly equivalent to 'generator.send(None)'
         self.assertEqual(__, generator.send(None))
-
-

--- a/python3/koans/about_iteration.py
+++ b/python3/koans/about_iteration.py
@@ -26,7 +26,7 @@ class AboutIteration(Koan):
         except StopIteration as ex:
             err_msg = 'Ran out of iterations'
 
-        self.assertRegexpMatches(err_msg, __)
+        self.assertRegex(err_msg, __)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_methods.py
+++ b/python3/koans/about_methods.py
@@ -24,7 +24,7 @@ class AboutMethods(Koan):
 
         # Note, the text comparison works for Python 3.2
         # It has changed in the past and may change in the future
-        self.assertRegexpMatches(msg,
+        self.assertRegex(msg,
             r'my_global_function\(\) missing 2 required positional arguments')
 
         try:
@@ -33,7 +33,7 @@ class AboutMethods(Koan):
             msg = e.args[0]
 
         # Note, watch out for parenthesis. They need slashes in front!
-        self.assertRegexpMatches(msg, __)
+        self.assertRegex(msg, __)
 
     # ------------------------------------------------------------------
 
@@ -126,7 +126,7 @@ class AboutMethods(Koan):
         return "ok"
 
     def test_the_documentation_can_be_viewed_with_the_doc_method(self):
-        self.assertRegexpMatches(self.method_with_documentation.__doc__, __)
+        self.assertRegex(self.method_with_documentation.__doc__, __)
 
     # ------------------------------------------------------------------
 
@@ -160,4 +160,3 @@ class AboutMethods(Koan):
 
         # Name mangling exists to avoid name clash issues when subclassing.
         # It is not for providing effective access protection
-

--- a/python3/koans/about_monkey_patching.py
+++ b/python3/koans/about_monkey_patching.py
@@ -35,7 +35,7 @@ class AboutMonkeyPatching(Koan):
         except Exception as ex:
             err_msg = ex.args[0]
 
-        self.assertRegexpMatches(err_msg, __)
+        self.assertRegex(err_msg, __)
 
     # ------------------------------------------------------------------
 
@@ -46,4 +46,3 @@ class AboutMonkeyPatching(Koan):
 
         self.assertEqual(__, self.MyInt(1).is_even())
         self.assertEqual(__, self.MyInt(2).is_even())
-

--- a/python3/koans/about_multiple_inheritance.py
+++ b/python3/koans/about_multiple_inheritance.py
@@ -87,7 +87,7 @@ class AboutMultipleInheritance(Koan):
 
     def test_normal_methods_are_available_in_the_object(self):
         jeff = self.Spiderpig()
-        self.assertRegexpMatches(jeff.speak(), __)
+        self.assertRegex(jeff.speak(), __)
 
     def test_base_class_methods_are_also_available_in_the_object(self):
         jeff = self.Spiderpig()
@@ -126,16 +126,15 @@ class AboutMultipleInheritance(Koan):
 
     def test_confirm_the_mro_controls_the_calling_order(self):
         jeff = self.Spiderpig()
-        self.assertRegexpMatches(jeff.here(), 'Spiderpig')
+        self.assertRegex(jeff.here(), 'Spiderpig')
 
         next = super(AboutMultipleInheritance.Spiderpig, jeff)
-        self.assertRegexpMatches(next.here(), 'Pig')
+        self.assertRegex(next.here(), 'Pig')
 
         next = super(AboutMultipleInheritance.Pig, jeff)
-        self.assertRegexpMatches(next.here(), __)
+        self.assertRegex(next.here(), __)
 
         # Hang on a minute?!? That last class name might be a super class of
         # the 'jeff' object, but its hardly a superclass of Pig, is it?
         #
         # To avoid confusion it may help to think of super() as next_mro().
-

--- a/python3/koans/about_none.py
+++ b/python3/koans/about_none.py
@@ -41,7 +41,7 @@ class AboutNone(Koan):
 
         # What message was attached to the exception?
         # (HINT: replace __ with part of the error message.)
-        self.assertRegexpMatches(ex2.args[0], __)
+        self.assertRegex(ex2.args[0], __)
 
     def test_none_is_distinct(self):
         """

--- a/python3/koans/about_tuples.py
+++ b/python3/koans/about_tuples.py
@@ -9,16 +9,17 @@ class AboutTuples(Koan):
         self.assertEqual(__, count_of_three[2])
 
     def test_tuples_are_immutable_so_item_assignment_is_not_possible(self):
-        count_of_three =  (1, 2, 5)
+
+        count_of_three = (1, 2, 5)
         try:
             count_of_three[2] = "three"
         except TypeError as ex:
             msg = ex.args[0]
 
-        # Note, assertRegexpMatches() uses regular expression pattern matching,
+        # Note, assertRegex() uses regular expression pattern matching,
         # so you don't have to copy the whole message.
 
-        self.assertRegexpMatches(msg, __)
+        self.assertRegex(msg, __)
 
     def test_tuples_are_immutable_so_appending_is_not_possible(self):
         count_of_three =  (1, 2, 5)
@@ -63,6 +64,3 @@ class AboutTuples(Koan):
 
         self.assertEqual(__, locations[2][0])
         self.assertEqual(__, locations[0][1][2])
-
-
-

--- a/python3/runner/koan.py
+++ b/python3/runner/koan.py
@@ -20,13 +20,4 @@ _____ = 0
 
 
 class Koan(unittest.TestCase):
-    def assertNoRegexpMatches(self, text, expected_regex, msg=None):
-        """
-        Throw an exception if the regular expresson pattern is not matched
-        """
-        if isinstance(expected_regex, (str, bytes)):
-            expected_regex = re.compile(expected_regex)
-        if expected_regex.search(text):
-            msg = msg or "Regexp matched"
-            msg = '{0}: {1!r} found in {2!r}'.format(msg, expected_regex.pattern, text)
-            raise self.failureException(msg)
+    pass


### PR DESCRIPTION
I noticed the python 3 koans were using the old form "assertRegexpMatches" and a homemade "assertNotRegexpMatches" test instead of the python3 built-ins "assertRegex" and "assertNotRegex.

I think it might be better to use the upgraded defaults, what do you think?