### PR TITLE
Changing variable name (Closes #117)

### DIFF
--- a/python3/koans/about_iteration.py
+++ b/python3/koans/about_iteration.py
@@ -8,12 +8,12 @@ class AboutIteration(Koan):
     def test_iterators_are_a_type(self):
         it = iter(range(1,6))
 
-        fib = 0
+        total = 0
 
         for num in it:
-            fib += num
+            total += num
 
-        self.assertEqual(__ , fib)
+        self.assertEqual(__ , total)
 
     def test_iterating_with_next(self):
         stages = iter(['alpha','beta','gamma'])


### PR DESCRIPTION
The variable name "fib" in test_iterators_are_a_type renamed to "total" to avoid confusion about what the function is doing.