### PR TITLE
about_generators

### DIFF
--- a/python2/koans/about_generators.py
+++ b/python2/koans/about_generators.py
@@ -91,12 +91,12 @@ class AboutGenerators(Koan):
 
     # ------------------------------------------------------------------
 
-    def generator_with_coroutine(self):
+    def coroutine(self):
         result = yield
         yield result
 
-    def test_generators_can_take_coroutines(self):
-        generator = self.generator_with_coroutine()
+    def test_generators_can_act_as_coroutines(self):
+        generator = self.coroutine()
 
         # THINK ABOUT IT:
         # Why is this line necessary?
@@ -108,7 +108,7 @@ class AboutGenerators(Koan):
         self.assertEqual(__, generator.send(1 + 2))
 
     def test_before_sending_a_value_to_a_generator_next_must_be_called(self):
-        generator = self.generator_with_coroutine()
+        generator = self.coroutine()
 
         try:
             generator.send(1 + 2)

--- a/python2/koans/about_generators.py
+++ b/python2/koans/about_generators.py
@@ -60,7 +60,7 @@ class AboutGenerators(Koan):
             result.append(item)
         self.assertEqual(__, result)
 
-    def test_coroutines_can_take_arguments(self):
+    def test_generators_can_be_manually_iterated_and_closed(self):
         result = self.simple_generator_method()
         self.assertEqual(__, next(result))
         self.assertEqual(__, next(result))

--- a/python2/koans/about_generators.py
+++ b/python2/koans/about_generators.py
@@ -43,8 +43,8 @@ class AboutGenerators(Koan):
         attempt1 = list(dynamite)
         attempt2 = list(dynamite)
 
-        self.assertEqual(__, list(attempt1))
-        self.assertEqual(__, list(attempt2))
+        self.assertEqual(__, attempt1)
+        self.assertEqual(__, attempt2)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -44,8 +44,8 @@ class AboutGenerators(Koan):
         attempt1 = list(dynamite)
         attempt2 = list(dynamite)
 
-        self.assertEqual(__, list(attempt1))
-        self.assertEqual(__, list(attempt2))
+        self.assertEqual(__, attempt1)
+        self.assertEqual(__, attempt2)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -112,11 +112,9 @@ class AboutGenerators(Koan):
         generator = self.coroutine()
 
         try:
-            generator.send(1+2)
+            generator.send(1 + 2)
         except TypeError as ex:
-          ex2 = ex
-
-        self.assertRegex(ex2.args[0], __)
+            self.assertRegex(ex.args[0], __)
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -92,12 +92,12 @@ class AboutGenerators(Koan):
 
     # ------------------------------------------------------------------
 
-    def generator_with_coroutine(self):
+    def coroutine(self):
         result = yield
         yield result
 
-    def test_generators_can_take_coroutines(self):
-        generator = self.generator_with_coroutine()
+    def test_generators_can_act_as_coroutines(self):
+        generator = self.coroutine()
 
         # THINK ABOUT IT:
         # Why is this line necessary?
@@ -109,7 +109,7 @@ class AboutGenerators(Koan):
         self.assertEqual(__, generator.send(1 + 2))
 
     def test_before_sending_a_value_to_a_generator_next_must_be_called(self):
-        generator = self.generator_with_coroutine()
+        generator = self.coroutine()
 
         try:
             generator.send(1+2)

--- a/python3/koans/about_generators.py
+++ b/python3/koans/about_generators.py
@@ -61,7 +61,7 @@ class AboutGenerators(Koan):
             result.append(item)
         self.assertEqual(__, result)
 
-    def test_coroutines_can_take_arguments(self):
+    def test_generators_can_be_manually_iterated_and_closed(self):
         result = self.simple_generator_method()
         self.assertEqual(__, next(result))
         self.assertEqual(__, next(result))


### PR DESCRIPTION
Closes #127 (I think)

This fixes some of the misleading method names in `about_generators.py` (2 & 3 versions), removes some redundant calls to `list()`, and makes the 2 and 3 versions a little more similar.


PS:  This is my first pull request, so be on the lookout for rookie errors.

Also, I tested these changes by running `python[23] contemplate_koans.py ridiculously.long.PathTo.test_function` while inserting and removing passing values in place of the double underscores.  Is there a better way --- either easier or less error-prone?  (I've never had a situation where the code-that-passes _can't_ be the code-that-is-committed.)