### PR TITLE
Test-name fixes

### DIFF
--- a/python3/koans/about_inheritance.py
+++ b/python3/koans/about_inheritance.py
@@ -25,7 +25,7 @@ class AboutInheritance(Koan):
     def test_subclasses_have_the_parent_as_an_ancestor(self):
         self.assertEqual(__, issubclass(self.Chihuahua, self.Dog))
 
-    def test_this_all_classes_in_python_3_ultimately_inherit_from_object_class(self):
+    def test_all_classes_in_python_3_ultimately_inherit_from_object_class(self):
         self.assertEqual(__, issubclass(self.Chihuahua, object))
 
         # Note: This isn't the case in Python 2. In that version you have

--- a/python3/koans/about_method_bindings.py
+++ b/python3/koans/about_method_bindings.py
@@ -83,7 +83,7 @@ class AboutMethodBindings(Koan):
 
     color = SuperColor()
 
-    def test_set_descriptor_changes_behavior_of_attribute_assignment_changes(self):
+    def test_set_descriptor_changes_behavior_of_attribute_assignment(self):
         self.assertEqual(None, self.color.choice)
         self.color = 'purple'
         self.assertEqual(__, self.color.choice)


### PR DESCRIPTION
Fixes two test name typos (both appeared only in the Python 3 files):

1.  `test_this_all_classes_in_python_3_ultimately_inherit_from_object_class` -> `test_all_classes_in_python_3_ultimately_inherit_from_object_class`

2.  `test_set_descriptor_changes_behavior_of_attribute_assignment_changes` -> `test_set_descriptor_changes_behavior_of_attribute_assignment`