### PR TITLE
Unmockify

### DIFF
--- a/python2/runner/runner_tests/test_mountain.py
+++ b/python2/runner/runner_tests/test_mountain.py
@@ -5,17 +5,14 @@ import unittest
 from libs.mock import *
 
 from runner.mountain import Mountain
-from runner import path_to_enlightenment
 
 class TestMountain(unittest.TestCase):
 
     def setUp(self):
-        path_to_enlightenment.koans = Mock()
         self.mountain = Mountain()
-        self.mountain.stream.writeln = Mock()
 
     def test_it_gets_test_results(self):
-        self.mountain.lesson.learn = Mock()
-        self.mountain.walk_the_path()
-        self.assertTrue(self.mountain.lesson.learn.called)
-
+        with patch_object(self.mountain.stream, 'writeln', Mock()):
+            with patch_object(self.mountain.lesson, 'learn', Mock()):
+                self.mountain.walk_the_path()
+                self.assertTrue(self.mountain.lesson.learn.called)

--- a/python2/runner/runner_tests/test_sensei.py
+++ b/python2/runner/runner_tests/test_sensei.py
@@ -10,7 +10,6 @@ from libs.mock import *
 from runner.sensei import Sensei
 from runner.writeln_decorator import WritelnDecorator
 from runner.mockable_test_result import MockableTestResult
-from runner import path_to_enlightenment
 
 class AboutParrots:
     pass
@@ -84,11 +83,7 @@ First differing element 1:
 class TestSensei(unittest.TestCase):
 
     def setUp(self):
-        self.sensei = Sensei(WritelnDecorator(sys.stdout))
-        self.sensei.stream.writeln = Mock()
-        path_to_enlightenment.koans = Mock()
-        self.tests = Mock()
-        self.tests.countTestCases = Mock()
+        self.sensei = Sensei(WritelnDecorator(Mock()))
 
     def test_that_failures_are_handled_in_the_base_class(self):
         MockableTestResult.addFailure = Mock()

--- a/python2/runner/runner_tests/test_sensei.py
+++ b/python2/runner/runner_tests/test_sensei.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import unittest
 import re
 
@@ -80,32 +79,33 @@ First differing element 1:
 
 """
 
+
 class TestSensei(unittest.TestCase):
 
     def setUp(self):
         self.sensei = Sensei(WritelnDecorator(Mock()))
 
     def test_that_failures_are_handled_in_the_base_class(self):
-        MockableTestResult.addFailure = Mock()
-        self.sensei.addFailure(Mock(), Mock())
-        self.assertTrue(MockableTestResult.addFailure.called)
+        with patch('runner.mockable_test_result.MockableTestResult.addFailure', Mock()):
+            self.sensei.addFailure(Mock(), Mock())
+            self.assertTrue(MockableTestResult.addFailure.called)
 
     def test_that_it_successes_only_count_if_passes_are_currently_allowed(self):
-        self.sensei.passesCount = Mock()
-        MockableTestResult.addSuccess = Mock()
-        self.sensei.addSuccess(Mock())
-        self.assertTrue(self.sensei.passesCount.called)
+        with patch('runner.mockable_test_result.MockableTestResult.addSuccess', Mock()):
+            self.sensei.passesCount = Mock()
+            self.sensei.addSuccess(Mock())
+            self.assertTrue(self.sensei.passesCount.called)
 
     def test_that_it_passes_on_add_successes_message(self):
-        MockableTestResult.addSuccess = Mock()
-        self.sensei.addSuccess(Mock())
-        self.assertTrue(MockableTestResult.addSuccess.called)
+        with patch('runner.mockable_test_result.MockableTestResult.addSuccess', Mock()):
+            self.sensei.addSuccess(Mock())
+            self.assertTrue(MockableTestResult.addSuccess.called)
 
     def test_that_it_increases_the_passes_on_every_success(self):
-        pass_count = self.sensei.pass_count
-        MockableTestResult.addSuccess = Mock()
-        self.sensei.addSuccess(Mock())
-        self.assertEqual(pass_count + 1, self.sensei.pass_count)
+        with patch('runner.mockable_test_result.MockableTestResult.addSuccess', Mock()):
+            pass_count = self.sensei.pass_count
+            self.sensei.addSuccess(Mock())
+            self.assertEqual(pass_count + 1, self.sensei.pass_count)
 
     def test_that_nothing_is_returned_as_a_first_result_if_there_are_no_failures(self):
         self.sensei.failures = []
@@ -231,7 +231,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 0
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
@@ -239,7 +238,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 1
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Explicit is better than implicit", words)
         self.assertTrue(m and m.group(0))
 
@@ -247,15 +245,13 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 10
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Sparse is better than dense", words)
         self.assertTrue(m and m.group(0))
 
     def test_that_if_there_is_36_successes_it_will_say_the_final_zen_of_python_koans(self):
-        self.sensei.pass_count = 36
         self.sensei.failures = Mock()
+        self.sensei.pass_count = 36
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Namespaces are one honking great idea", words)
         self.assertTrue(m and m.group(0))
 
@@ -263,26 +259,22 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 37
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
     def test_that_total_lessons_return_7_if_there_are_7_lessons(self):
         self.sensei.filter_all_lessons = Mock()
         self.sensei.filter_all_lessons.return_value = [1,2,3,4,5,6,7]
-
         self.assertEqual(7, self.sensei.total_lessons())
 
     def test_that_total_lessons_return_0_if_all_lessons_is_none(self):
         self.sensei.filter_all_lessons = Mock()
         self.sensei.filter_all_lessons.return_value = None
-
         self.assertEqual(0, self.sensei.total_lessons())
 
     def test_total_koans_return_43_if_there_are_43_test_cases(self):
         self.sensei.tests.countTestCases = Mock()
         self.sensei.tests.countTestCases.return_value = 43
-
         self.assertEqual(43, self.sensei.total_koans())
 
     def test_filter_all_lessons_will_discover_test_classes_if_none_have_been_discovered_yet(self):

--- a/python3/runner/runner_tests/test_mountain.py
+++ b/python3/runner/runner_tests/test_mountain.py
@@ -5,17 +5,14 @@ import unittest
 from libs.mock import *
 
 from runner.mountain import Mountain
-from runner import path_to_enlightenment
 
 class TestMountain(unittest.TestCase):
 
     def setUp(self):
-        path_to_enlightenment.koans = Mock()
         self.mountain = Mountain()
-        self.mountain.stream.writeln = Mock()
 
     def test_it_gets_test_results(self):
-        self.mountain.lesson.learn = Mock()
-        self.mountain.walk_the_path()
-        self.assertTrue(self.mountain.lesson.learn.called)
-
+        with patch_object(self.mountain.stream, 'writeln', Mock()):
+            with patch_object(self.mountain.lesson, 'learn', Mock()):
+                self.mountain.walk_the_path()
+                self.assertTrue(self.mountain.lesson.learn.called)

--- a/python3/runner/runner_tests/test_sensei.py
+++ b/python3/runner/runner_tests/test_sensei.py
@@ -10,7 +10,6 @@ from libs.mock import *
 from runner.sensei import Sensei
 from runner.writeln_decorator import WritelnDecorator
 from runner.mockable_test_result import MockableTestResult
-from runner import path_to_enlightenment
 
 class AboutParrots:
     pass
@@ -85,11 +84,7 @@ First differing element 1:
 class TestSensei(unittest.TestCase):
 
     def setUp(self):
-        self.sensei = Sensei(WritelnDecorator(sys.stdout))
-        self.sensei.stream.writeln = Mock()
-        path_to_enlightenment.koans = Mock()
-        self.tests = Mock()
-        self.tests.countTestCases = Mock()
+        self.sensei = Sensei(WritelnDecorator(Mock()))
 
     def test_that_it_successes_only_count_if_passes_are_currently_allowed(self):
         self.sensei.passesCount = Mock()

--- a/python3/runner/runner_tests/test_sensei.py
+++ b/python3/runner/runner_tests/test_sensei.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import unittest
 import re
 
@@ -31,7 +30,7 @@ class AboutFreemasons:
     pass
 
 error_assertion_with_message = """Traceback (most recent call last):
-  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py ", line 43, in test_durability
+  File "/Users/Greg/hg/python_koans/koans/about_exploding_trousers.py", line 43, in test_durability
     self.assertEqual("Steel","Lard", "Another fine mess you've got me into Stanley...")
 AssertionError: Another fine mess you've got me into Stanley..."""
 
@@ -87,16 +86,16 @@ class TestSensei(unittest.TestCase):
         self.sensei = Sensei(WritelnDecorator(Mock()))
 
     def test_that_it_successes_only_count_if_passes_are_currently_allowed(self):
-        self.sensei.passesCount = Mock()
-        MockableTestResult.addSuccess = Mock()
-        self.sensei.addSuccess(Mock())
-        self.assertTrue(self.sensei.passesCount.called)
+        with patch('runner.mockable_test_result.MockableTestResult.addSuccess', Mock()):
+            self.sensei.passesCount = Mock()
+            self.sensei.addSuccess(Mock())
+            self.assertTrue(self.sensei.passesCount.called)
 
     def test_that_it_increases_the_passes_on_every_success(self):
-        pass_count = self.sensei.pass_count
-        MockableTestResult.addSuccess = Mock()
-        self.sensei.addSuccess(Mock())
-        self.assertEqual(pass_count + 1, self.sensei.pass_count)
+        with patch('runner.mockable_test_result.MockableTestResult.addSuccess', Mock()):
+            pass_count = self.sensei.pass_count
+            self.sensei.addSuccess(Mock())
+            self.assertEqual(pass_count + 1, self.sensei.pass_count)
 
     def test_that_nothing_is_returned_as_sorted_result_if_there_are_no_failures(self):
         self.sensei.failures = []
@@ -211,7 +210,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 0
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
@@ -219,7 +217,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 1
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Explicit is better than implicit", words)
         self.assertTrue(m and m.group(0))
 
@@ -227,7 +224,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 10
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Sparse is better than dense", words)
         self.assertTrue(m and m.group(0))
 
@@ -235,7 +231,6 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 36
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Namespaces are one honking great idea", words)
         self.assertTrue(m and m.group(0))
 
@@ -243,26 +238,22 @@ class TestSensei(unittest.TestCase):
         self.sensei.pass_count = 37
         self.sensei.failures = Mock()
         words = self.sensei.say_something_zenlike()
-
         m = re.search("Beautiful is better than ugly", words)
         self.assertTrue(m and m.group(0))
 
     def test_that_total_lessons_return_7_if_there_are_7_lessons(self):
         self.sensei.filter_all_lessons = Mock()
         self.sensei.filter_all_lessons.return_value = [1,2,3,4,5,6,7]
-
         self.assertEqual(7, self.sensei.total_lessons())
 
     def test_that_total_lessons_return_0_if_all_lessons_is_none(self):
         self.sensei.filter_all_lessons = Mock()
         self.sensei.filter_all_lessons.return_value = None
-
         self.assertEqual(0, self.sensei.total_lessons())
 
     def test_total_koans_return_43_if_there_are_43_test_cases(self):
         self.sensei.tests.countTestCases = Mock()
         self.sensei.tests.countTestCases.return_value = 43
-
         self.assertEqual(43, self.sensei.total_koans())
 
     def test_filter_all_lessons_will_discover_test_classes_if_none_have_been_discovered_yet(self):


### PR DESCRIPTION
Python 2 and 3:  Replaces several `<globally_visible_thing> = Mock()` assignments with `with patch(...):` and `with patch_object(...):` blocks, to prevent `Mock` objects leaking out of their tests into others.

For example, after `test_mountain` or `test_sensei` ran `path_to_enlightenment.koans = Mock()`, it was impossible to test the `koans` function --- it just kept returning `Mock`.  (That specific mock seemed completely unneeded anyway, so I removed it.  The `_runner_tests.py` outputs didn't change.)