### PR TITLE
Fixes #137: test_everything_else_is_treated_as_true

### DIFF
--- a/python2/koans/about_true_and_false.py
+++ b/python2/koans/about_true_and_false.py
@@ -34,7 +34,8 @@ class AboutTrueAndFalse(Koan):
 
     def test_everything_else_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(1))
-        self.assertEqual(__, self.truth_value(1,))
+        self.assertEqual(__, self.truth_value([0]))
+        self.assertEqual(__, self.truth_value((0,)))
         self.assertEqual(
             __,
             self.truth_value("Python is named after Monty Python"))

--- a/python3/koans/about_true_and_false.py
+++ b/python3/koans/about_true_and_false.py
@@ -3,6 +3,7 @@
 
 from runner.koan import *
 
+
 class AboutTrueAndFalse(Koan):
     def truth_value(self, condition):
         if condition:
@@ -33,7 +34,10 @@ class AboutTrueAndFalse(Koan):
 
     def test_everything_else_is_treated_as_true(self):
         self.assertEqual(__, self.truth_value(1))
-        self.assertEqual(__, self.truth_value(1,))
-        self.assertEqual(__, self.truth_value("Python is named after Monty Python"))
+        self.assertEqual(__, self.truth_value([0]))
+        self.assertEqual(__, self.truth_value((0,)))
+        self.assertEqual(
+            __,
+            self.truth_value("Python is named after Monty Python"))
         self.assertEqual(__, self.truth_value(' '))
         self.assertEqual(__, self.truth_value('0'))


### PR DESCRIPTION
Fixes #137

In the Python 2 and 3 versions of koans/about_true_and_false.py:

self.truth_value(1,) is an integer argument followed by an optional
comma.  It just happened to produce the desired answer, because bool(1)
is True.

self.truth_value((1,)) is a tuple argument.  Changed the tuple to (0,)
to demonstrate that its truthiness comes from the presence of _any_
elements, and not from the truth value of the element itself.

Also, added an easier example before it --- self.truth_value([0]) ---
to introduce the same idea with the simpler list-literal syntax (no
"magic" comma to worry about).

Finally, changed the whitespace and line wrapping so the Python 2 and 3
files are identical.

Reported by: egonluo
https://github.com/egonluo

Issue #137:
https://github.com/gregmalcolm/python_koans/issues/137