### PR TITLE
about_with_statement.py has a boken test on line 98

### DIFF
--- a/python3/koans/about_with_statements.py
+++ b/python3/koans/about_with_statements.py
@@ -95,7 +95,10 @@ class AboutWithStatements(Koan):
 
     def test_finding_lines2(self):
         self.assertEqual(__, self.find_line2("example_file.txt"))
-        self.assertNotEqual(__, self.find_line2("example_file.txt"))
+        # The test below is broken as it accepts the default placeholder (__) as
+        # an answer. In fact it accepts anything that is not 'test\n' as an
+        # answer.
+        # self.assertNotEqual(__, self.find_line2("example_file.txt"))
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
The default placeholder value of __ can be left as is and the test will pass. I might be mistaken but it seems like an unexpected behavior to me..? 