### PR TITLE
Whitespace fixes from Py2 version applied to Py3.

### DIFF
--- a/python3/koans/about_regex.py
+++ b/python3/koans/about_regex.py
@@ -2,11 +2,15 @@
 # -*- coding: utf-8 -*-
 
 from runner.koan import *
+
 import re
+
+
 class AboutRegex(Koan):
     """
-        These koans are based on the Ben's book: Regular Expressions in 10 minutes.
-        I found this books very useful so I decided to write a koans in order to practice everything I had learned from it.
+        These koans are based on Ben's book: Regular Expressions in 10
+        minutes. I found this book very useful, so I decided to write
+        a koan file in order to practice everything it taught me.
         http://www.forta.com/books/0672325667/
     """
 
@@ -14,47 +18,60 @@ class AboutRegex(Koan):
         """
             Lesson 1 Matching Literal String
         """
-        string = "Hello, my name is Felix and this koans are based on the Ben's book: Regular Expressions in 10 minutes."
+        string = "Hello, my name is Felix and these koans are based " + \
+        "on Ben's book: Regular Expressions in 10 minutes."
         m = re.search(__, string)
-        self.assertTrue(m and m.group(0) and m.group(0)== 'Felix', "I want my name")
+        self.assertTrue(
+            m and m.group(0) and
+                m.group(0) == 'Felix',
+            "I want my name")
 
     def test_matching_literal_text_how_many(self):
         """
-            Lesson 1 How many matches?
+            Lesson 1 -- How many matches?
 
-            The default behaviour of most regular expression engines is to return just the first match.
-            In python you have the next options:
+            The default behaviour of most regular expression engines is
+            to return just the first match. In python you have the
+            following options:
 
-                match()    -->  Determine if the RE matches at the beginning of the string.
-                search()   -->  Scan through a string, looking for any location where this RE matches.
-                findall()  -->  Find all substrings where the RE matches, and returns them as a list.
-                finditer() -->  Find all substrings where the RE matches, and returns them as an iterator.
-
+                match()    -->  Determine if the RE matches at the
+                                beginning of the string.
+                search()   -->  Scan through a string, looking for any
+                                location where this RE matches.
+                findall()  -->  Find all substrings where the RE
+                                matches, and return them as a list.
+                finditer() -->  Find all substrings where the RE
+                                matches, and return them as an iterator.
         """
-        string = "Hello, my name is Felix and this koans are based on the Ben's book: Regular Expressions in 10 minutes. Repeat My name is Felix"
-        m = re.match('Felix', string) #TIP: Maybe match it's not the best option
+        string = ("Hello, my name is Felix and these koans are based " +
+            "on Ben's book: Regular Expressions in 10 minutes. " +
+            "Repeat My name is Felix")
+        m = re.match('Felix', string)  # TIP: match may not be the best option
 
-        # I want to know how many times appears my name
+        # I want to know how many times my name appears
         self.assertEqual(m, __)
 
     def test_matching_literal_text_not_case_sensitivity(self):
         """
-            Lesson 1 Matching Literal String non case sensitivity.
-            Most regex implementations also support matches that are not case sensitive. In python you can use re.IGNORECASE, in
-            Javascript you can specify the optional i flag.
-            In Ben's book you can see more languages.
+            Lesson 1 -- Matching Literal String non case sensitivity.
+            Most regex implementations also support matches that are not
+            case sensitive. In python you can use re.IGNORECASE, in
+            Javascript you can specify the optional i flag. In Ben's
+            book you can see more languages.
 
         """
-        string = "Hello, my name is Felix or felix and this koans is based on the Ben's book: Regular Expressions in 10 minutes."
+        string = "Hello, my name is Felix or felix and this koan " + \
+            "is based on Ben's book: Regular Expressions in 10 minutes."
 
         self.assertEqual(re.findall("felix", string), __)
         self.assertEqual(re.findall("felix", string, re.IGNORECASE), __)
 
     def test_matching_any_character(self):
         """
-            Lesson 1 Matching any character
+            Lesson 1: Matching any character
 
-            . matches any character, alphabetic characters, digits and .
+            `.` matches any character: alphabetic characters, digits,
+            and punctuation.
         """
         string = "pecks.xlx\n"    \
                 + "orders1.xls\n" \
@@ -63,17 +80,19 @@ class AboutRegex(Koan):
                 + "na2.xls\n"     \
                 + "sa1.xls"
 
-        # TIP: remember the name of this lesson
-
-        change_this_search_string = 'a..xlx' # <-- I want to find all uses of myArray
-        self.assertEquals(len(re.findall(change_this_search_string, string)),3)
+        # I want to find all uses of myArray
+        change_this_search_string = 'a..xlx'
+        self.assertEquals(
+            len(re.findall(change_this_search_string, string)),
+            3)
 
     def test_matching_set_character(self):
         """
-            Lesson 2 Matching sets of characters
+            Lesson 2 -- Matching sets of characters
 
-            A set of characters is defined using the metacharacters [ and ]. Everything between them is part of the set and
-            any one of the set members must match (but not all).
+            A set of characters is defined using the metacharacters
+            `[` and `]`. Everything between them is part of the set, and
+            any single one of the set members will match.
         """
         string = "sales.xlx\n"    \
                 + "sales1.xls\n"  \
@@ -84,16 +103,21 @@ class AboutRegex(Koan):
                 + "na2.xls\n"  \
                 + "sa1.xls\n"  \
                 + "ca1.xls"
-        # I want to find all files for North America(na) or South America(sa), but not (ca)
-        # TIP you can use the pattern .a. which matches in above test but in this case matches more than you want
+        # I want to find all files for North America(na) or South
+        # America(sa), but not (ca) TIP you can use the pattern .a.
+        # which matches in above test but in this case matches more than
+        # you want
         change_this_search_string = '[nsc]a[2-9].xls'
-        self.assertEquals(len(re.findall(change_this_search_string, string)),3)
+        self.assertEquals(
+            len(re.findall(change_this_search_string, string)),
+            3)
 
     def test_anything_but_matching(self):
         """
-            Lesson 2 Using character set ranges
-            Occasionally, you'll want a list of characters that you don't want to match.
-            Character sets can be negated using the ^ metacharacter.
+            Lesson 2 -- Using character set ranges
+            Occasionally, you'll have a list of characters that you don't
+            want to match. Character sets can be negated using the ^
+            metacharacter.
 
         """
         string = "sales.xlx\n"    \
@@ -109,8 +133,8 @@ class AboutRegex(Koan):
                 + "sa1.xls\n"  \
                 + "ca1.xls"
 
-        # I want to find the name sam
+        # I want to find the name 'sam'
         change_this_search_string = '[^nc]am'
-        self.assertEquals(re.findall(change_this_search_string, string), ['sam.xls'])
-
-
+        self.assertEquals(
+            re.findall(change_this_search_string, string),
+            ['sam.xls'])


### PR DESCRIPTION
This makes the Python 3 version of about_regex.py identical to the
Python 2 version.

Most of the whitespace and grammar fixes were made to only the Python 2
version on Fri 10 Feb 2012 by gregmalcolm, as part of a larger commit:

Merged generators fix from engored and pep8 fixes from sietsebb via bitbucket mirror
https://github.com/gregmalcolm/python_koans/commit/d65e6904712416c663abd2a67dcf2d71153015c2#diff-612bda3dc05c74b8fdd16c0df2dd28c8

(Only about a half-dozen minor changes have been made since then.)