### PR TITLE
Python 3 test_finding_lines2() assert passes as-is

### DIFF
--- a/python2/koans/about_with_statements.py
+++ b/python2/koans/about_with_statements.py
@@ -91,12 +91,13 @@ class AboutWithStatements(Koan):
     # ------------------------------------------------------------------
 
     def find_line2(self, file_name):
-        # Rewrite find_line using the Context Manager.
-        pass
+        # Using the context manager self.FileContextManager, rewrite this
+        # function to return the first line containing the letter 'e'.
+        return None
 
     def test_finding_lines2(self):
-        self.assertEqual(__, self.find_line2("example_file.txt"))
         self.assertNotEqual(None, self.find_line2("example_file.txt"))
+        self.assertEqual('test\n', self.find_line2("example_file.txt"))
 
     # ------------------------------------------------------------------
 

--- a/python3/koans/about_with_statements.py
+++ b/python3/koans/about_with_statements.py
@@ -90,12 +90,13 @@ class AboutWithStatements(Koan):
     # ------------------------------------------------------------------
 
     def find_line2(self, file_name):
-        # Rewrite find_line using the Context Manager.
-        pass
+        # Using the context manager self.FileContextManager, rewrite this
+        # function to return the first line containing the letter 'e'.
+        return None
 
     def test_finding_lines2(self):
-        self.assertEqual(__, self.find_line2("example_file.txt"))
-        self.assertNotEqual(__, self.find_line2("example_file.txt"))
+        self.assertNotEqual(None, self.find_line2("example_file.txt"))
+        self.assertEqual('test\n', self.find_line2("example_file.txt"))
 
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes issue #169, reported in @denis-roy's pull request #157:  The Python 3 version of `AboutWithStatements.test_finding_lines2` contains an `assertNotEqual(__, ...)` that passes without the student having to change anything.

I think the idea was that the `assertNotEqual` would test that the student-written function returns _anything_ (by default, the `pass` statement returns `None`), while the `assertEqual` would test that furthermore the return value is correct.

In this version, the general (not-`None`) assertion is tested before the specific.  Also, both assertions have the passing / expected values hard-coded, meaning the student should change only the function they test, not the assertions themselves.