### PR TITLE
Fix wrong filename for extra credit koan

### DIFF
--- a/python2/runner/sensei.py
+++ b/python2/runner/sensei.py
@@ -99,7 +99,7 @@ class Sensei(MockableTestResult):
         self.stream.writeln("\n{0}That was the last one, well done!" \
             .format(Fore.MAGENTA))
         self.stream.writeln(
-            "\nIf you want more, take a look at about_extra_credit_task.py")
+            "\nIf you want more, take a look at about_extra_credit.py")
 
     def errorReport(self):
         problem = self.firstFailure()

--- a/python3/runner/sensei.py
+++ b/python3/runner/sensei.py
@@ -98,7 +98,7 @@ class Sensei(MockableTestResult):
         self.stream.writeln("\n{0}That was the last one, well done!" \
             .format(Fore.MAGENTA))
         self.stream.writeln(
-            "\nIf you want more, take a look at about_extra_credit_task.py{0}{1}" \
+            "\nIf you want more, take a look at about_extra_credit.py{0}{1}" \
             .format(Fore.RESET, Style.NORMAL))
 
     def errorReport(self):


### PR DESCRIPTION
Hello!

It seems that the filename in this sentence about the extra credit koan is wrong in both python 2 and 3 versions.
I suggest to fix it, so that it matches the actual file.

Thanks