### PR TITLE
Deleted type of object answer

### DIFF
--- a/python3/koans/about_lists.py
+++ b/python3/koans/about_lists.py
@@ -10,7 +10,7 @@ from runner.koan import *
 class AboutLists(Koan):
     def test_creating_lists(self):
         empty_list = list()
-        self.assertEqual(list, type(empty_list))
+        self.assertEqual(__, type(empty_list))
         self.assertEqual(__, len(empty_list))
 
     def test_list_literals(self):


### PR DESCRIPTION
Removed answer from `def test_creating_lists(self)` for type for first assertion `type(empty_list)`
I suppose, the one who learn, should type answer `list` himself, isn`t he?