### PR TITLE
Change bit.ly/__class__ links to repo wiki links

### DIFF
--- a/python2/koans/about_asserts.py
+++ b/python2/koans/about_asserts.py
@@ -76,4 +76,4 @@ class AboutAsserts(Koan):
 
         # Need an illustration? More reading can be found here:
         #
-        #   http://bit.ly/__class__
+        #   https://github.com/gregmalcolm/python_koans/wiki/Class-Attribute

--- a/python3/koans/about_asserts.py
+++ b/python3/koans/about_asserts.py
@@ -74,5 +74,5 @@ class AboutAsserts(Koan):
 
         # Need an illustration? More reading can be found here:
         #
-        #   https://github.com/gregmalcolm/python_koans/wiki/Class-Attribute_
+        #   https://github.com/gregmalcolm/python_koans/wiki/Class-Attribute
 

--- a/python3/koans/about_asserts.py
+++ b/python3/koans/about_asserts.py
@@ -74,5 +74,5 @@ class AboutAsserts(Koan):
 
         # Need an illustration? More reading can be found here:
         #
-        #   http://bit.ly/__class__
+        #   https://github.com/gregmalcolm/python_koans/wiki/Class-Attribute_
 

--- a/python3/koans/about_none.py
+++ b/python3/koans/about_none.py
@@ -35,7 +35,7 @@ class AboutNone(Koan):
         #
         # Need a recap on how to evaluate __class__ attributes?
         #
-        #     http://bit.ly/__class__
+        #     https://github.com/gregmalcolm/python_koans/wiki/Class-Attribute
 
         self.assertEqual(__, ex2.__class__)
 


### PR DESCRIPTION
replaced bit.ly/__class__ links to direct links of the repo wiki page in order to remove confusion