### PR TITLE
Drop support for EOL Python 3.2-3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.2
-    - 3.3
-    - 3.4
     - 3.5
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ need to install the Python interpreter.
 At this time of writing, there are two versions of the Python Koans:
 
 * one for use with Python 2.7 (earlier versions are no longer supported)
-* one for Python 3.1+
+* one for Python 3.5+
 
 You should be able to work with newer Python versions, but older ones will
 likely give you problems.


### PR DESCRIPTION
Fixes #194. 

Python 3.2-3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

Python 3.2 and 3.3 are also failing on Travis CI as they've also dropped them.
