### PR TITLE
Fix pypiwin32 instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,15 +145,11 @@ On Linux::
 On Windows::
 
     $ pip install pywin32
+
+    Also available here:
     
-(If that failed, try::
-    
-    $ pip install pypiwin32
- 
- then grab a proper version of pypiwin32 installer and install it::
- 
     https://github.com/mhammond/pywin32/releases
-)
+
 
 On Mac OS X::
 

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,10 @@ On Windows::
 (If that failed, try::
     
     $ pip install pypiwin32
+ 
+ then grab a proper version of pypiwin32 installer and install it::
+ 
+    https://github.com/mhammond/pywin32/releases
 )
 
 On Mac OS X::


### PR DESCRIPTION
Slight modification to @chuaaron's PR to simplify the pywin32 installation instructions.

I think things have stabilized some and we'll be losing Python 2 support soon anyway