### PR TITLE
Minor addition to list assignments (*splat unpacking with fewer values)

### DIFF
--- a/koans/about_list_assignments.py
+++ b/koans/about_list_assignments.py
@@ -23,6 +23,12 @@ class AboutListAssignments(Koan):
         self.assertEqual(__, first_names)
         self.assertEqual(__, last_name)
 
+    def test_parallel_assignments_with_fewer_values(self):
+        title, *first_names, last_name = ["Mr", "Bond"]
+        self.assertEqual(__, title)
+        self.assertEqual(__, first_names)
+        self.assertEqual(__, last_name)
+
     def test_parallel_assignments_with_sublists(self):
         first_name, last_name = [["Willie", "Rae"], "Johnson"]
         self.assertEqual(__, first_name)


### PR DESCRIPTION
Hi Greg,

Minor addition to demonstrate what happens to the **rest** variable when there are fewer values.
    
    title, *first_names, last_name = ["Mr", "Bond"]

Feel free to amend/reject as you see fit.