### PR TITLE
Fix: change 'is not' to inequality operator.

### DIFF
--- a/koans/about_none.py
+++ b/koans/about_none.py
@@ -47,5 +47,5 @@ class AboutNone(Koan):
         """
         None is distinct from other things which are False.
         """
-        self.assertEqual(__, None is not 0)
-        self.assertEqual(__, None is not False)
+        self.assertEqual(__, None != 0)
+        self.assertEqual(__, None != False)

--- a/koans/about_none.py
+++ b/koans/about_none.py
@@ -7,8 +7,8 @@
 
 from runner.koan import *
 
-class AboutNone(Koan):
 
+class AboutNone(Koan):
     def test_none_is_an_object(self):
         "Unlike NULL in a lot of languages"
         self.assertEqual(__, isinstance(None, object))
@@ -47,5 +47,5 @@ class AboutNone(Koan):
         """
         None is distinct from other things which are False.
         """
-        self.assertEqual(__, None != 0)
-        self.assertEqual(__, None != False)
+        self.assertEqual(__, None != 0)  # noqa
+        self.assertEqual(__, None != False)  # noqa


### PR DESCRIPTION
It rely on issue: https://github.com/gregmalcolm/python_koans/issues/248
I suggest !=, because it more broad than is.

Feel free to amend/reject as you see fit.