### PR TITLE
Update File

### DIFF
--- a/koans/about_dictionaries.py
+++ b/koans/about_dictionaries.py
@@ -36,7 +36,7 @@ class AboutDictionaries(Koan):
         dict1 = { 'one': 'uno', 'two': 'dos' }
         dict2 = { 'two': 'dos', 'one': 'uno' }
 
-        self.assertEqual(__, dict1 == dict2)
+        self.assertEqual(__, enumerate(dict1) == enumerate(dict2))
 
 
     def test_dictionary_keys_and_values(self):


### PR DESCRIPTION
Updated about_dictionaries.py to fix false-positives from test_dictionary_is_unordered(self) due to dict1 == dict2 not giving the correct output of showing that two differently ordered dictionaries are not equal. This was mentioned in issue [#240](https://github.com/gregmalcolm/python_koans/issues/240 "Issue Link").