### PR TITLE
Update deprecated assertEquals to assertEqual

### DIFF
--- a/koans/about_iteration.py
+++ b/koans/about_iteration.py
@@ -80,7 +80,7 @@ class AboutIteration(Koan):
         except StopIteration:
             msg = 'Ran out of big names'
 
-        self.assertEquals(__, msg)
+        self.assertEqual(__, msg)
 
     # ------------------------------------------------------------------
 

--- a/koans/about_regex.py
+++ b/koans/about_regex.py
@@ -82,7 +82,7 @@ class AboutRegex(Koan):
 
         # I want to find all uses of myArray
         change_this_search_string = 'a..xlx'
-        self.assertEquals(
+        self.assertEqual(
             len(re.findall(change_this_search_string, string)),
             3)
 
@@ -108,7 +108,7 @@ class AboutRegex(Koan):
         # which matches in above test but in this case matches more than
         # you want
         change_this_search_string = '[nsc]a[2-9].xls'
-        self.assertEquals(
+        self.assertEqual(
             len(re.findall(change_this_search_string, string)),
             3)
 
@@ -135,6 +135,6 @@ class AboutRegex(Koan):
 
         # I want to find the name 'sam'
         change_this_search_string = '[^nc]am'
-        self.assertEquals(
+        self.assertEqual(
             re.findall(change_this_search_string, string),
             ['sam.xls'])

--- a/runner/runner_tests/test_helper.py
+++ b/runner/runner_tests/test_helper.py
@@ -11,7 +11,7 @@ class TestHelper(unittest.TestCase):
         self.assertEqual("str", helper.cls_name(str()))
 
     def test_that_get_class_name_works_with_a_4(self):
-        self.assertEquals("int", helper.cls_name(4))
+        self.assertEqual("int", helper.cls_name(4))
 
     def test_that_get_class_name_works_with_a_tuple(self):
-        self.assertEquals("tuple", helper.cls_name((3,"pie", [])))
+        self.assertEqual("tuple", helper.cls_name((3,"pie", [])))


### PR DESCRIPTION
Replace deprecated assertEquals with assertEqual.  Running through the koans one by one, I got this error message on koans/about_iteration.py:

```  test_filter_returns_all_items_matching_criterion has damaged your karma.

You have not yet reached enlightenment ...
  AttributeError: 'AboutIteration' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?
```

I checked that the koans still run normally after the fix.
