### PR TITLE
Disable PYTHON_COLORS in run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-python3 -B contemplate_koans.py
-
+PYTHON_COLORS=0 python3 -B contemplate_koans.py


### PR DESCRIPTION
Fix issue is with syntax and output coloring in Python 3.14 that interferes with output stream wrapper. Add prefix `PYTHON_COLORS=0` to the python3 invocation line in `run.sh`. This disables the output coloring function within the Python interpreter but does not affect output coloring from libraries or other components. The koans now run and complete successfully in 3.14. (Issue #295)